### PR TITLE
Show/hide multi-root session folder picker for agent-host sessions

### DIFF
--- a/src/vs/platform/agentHost/common/agent.ts
+++ b/src/vs/platform/agentHost/common/agent.ts
@@ -1061,14 +1061,11 @@ export interface IAgent {
 	/**
 	 * Optional provider-owned decision about the multi-root new-session Folder
 	 * picker, computed from the ordered working-directory set (index 0 = the
-	 * currently chosen primary). Returns `undefined` when the provider expresses
-	 * no opinion (the client then shows the picker as usual). The signal is
-	 * provider-specific — e.g. Copilot hides the picker when at most one working
-	 * directory carries hooks (pinning a primary when exactly one does) and shows
-	 * it when several do — so it lives on the agent rather than in shared
-	 * orchestration. The result is seeded into the session's `_meta` at creation
-	 * for the client to consume. The optional {@link token} aborts the (possibly
-	 * filesystem-bound) computation if the caller no longer needs it.
+	 * current primary) and seeded into the session's `_meta` at creation for the
+	 * client. Returns `undefined` when the provider has no opinion: nothing is
+	 * seeded and the client keeps the picker hidden by default, so a provider
+	 * that wants it shown must say so with `{ hidden: false }`. The optional
+	 * {@link token} aborts the (possibly filesystem-bound) computation.
 	 */
 	computeFolderPickerDecision?(workingDirectories: readonly URI[], token?: CancellationToken): Promise<ISessionFolderPickerDecision | undefined>;
 

--- a/src/vs/platform/agentHost/common/agent.ts
+++ b/src/vs/platform/agentHost/common/agent.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../base/common/event.js';
+import { CancellationToken } from '../../../base/common/cancellation.js';
 import { DisposableStore, IDisposable } from '../../../base/common/lifecycle.js';
 import { IChannelClient } from '../../../base/parts/ipc/common/ipc.js';
 import { truncate } from '../../../base/common/strings.js';
@@ -16,7 +17,7 @@ import type { AgentHostClientType } from './agentHostClientInfo.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from './state/protocol/commands.js';
 import { ProtectedResourceMetadata, type Changeset, type ChatOrigin, type ConfigSchema, type MessageAttachment, type ModelSelection, type AgentSelection, type SessionActiveClient, type ToolCallPendingConfirmationState, type ToolDefinition, ChangesSummary } from './state/protocol/state.js';
 import type { AuthRequiredParams, SessionAction, ChatAction } from './state/sessionActions.js';
-import { ChatInputResponseKind, ChatOriginKind, SessionStatus, buildSubagentChatUri, parseRequiredSessionUriFromChatUri, type AgentCapabilities, type ClientPluginCustomization, type Customization, type Message, type PendingMessage, type ChatInputAnswer, type SessionMeta, type ToolCallResult, type Turn, type PolicyState } from './state/sessionState.js';
+import { ChatInputResponseKind, ChatOriginKind, SessionStatus, buildSubagentChatUri, parseRequiredSessionUriFromChatUri, type AgentCapabilities, type ClientPluginCustomization, type Customization, type ISessionFolderPickerDecision, type Message, type PendingMessage, type ChatInputAnswer, type SessionMeta, type ToolCallResult, type Turn, type PolicyState } from './state/sessionState.js';
 
 export interface IAgentHostConnection {
 	readonly client: IChannelClient;
@@ -1056,6 +1057,20 @@ export interface IAgent {
 
 	/** Returns host-internal plugin owners for MCP servers temporarily published top-level. */
 	getMcpServerOwners?(session: URI): ReadonlyMap<string, string> | undefined;
+
+	/**
+	 * Optional provider-owned decision about the multi-root new-session Folder
+	 * picker, computed from the ordered working-directory set (index 0 = the
+	 * currently chosen primary). Returns `undefined` when the provider expresses
+	 * no opinion (the client then shows the picker as usual). The signal is
+	 * provider-specific — e.g. Copilot hides the picker when at most one working
+	 * directory carries hooks (pinning a primary when exactly one does) and shows
+	 * it when several do — so it lives on the agent rather than in shared
+	 * orchestration. The result is seeded into the session's `_meta` at creation
+	 * for the client to consume. The optional {@link token} aborts the (possibly
+	 * filesystem-bound) computation if the caller no longer needs it.
+	 */
+	computeFolderPickerDecision?(workingDirectories: readonly URI[], token?: CancellationToken): Promise<ISessionFolderPickerDecision | undefined>;
 
 	// ---- External chat discovery -------------------------------------------
 

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1274,6 +1274,79 @@ export function withSessionPromptCacheState(meta: SessionMeta | undefined, promp
 	return Object.keys(next).length > 0 ? next : undefined;
 }
 
+/** Reserved key for the harness-owned new-session folder-picker decision. */
+export const SESSION_META_FOLDER_PICKER_KEY = 'vscode.folderPicker';
+
+/**
+ * Harness-owned decision about the multi-root new-session Folder picker for an
+ * agent-host session, carried under {@link SessionMeta} at
+ * {@link SESSION_META_FOLDER_PICKER_KEY}.
+ *
+ * The provider (harness) owns this because the signal differs per backend — for
+ * example Copilot hides the picker when at most one workspace folder carries
+ * hooks under `.github/hooks/` (pinning that folder as {@link primary} when
+ * exactly one does), since the Copilot agent only applies hooks from the primary
+ * working directory, and shows the picker when several folders carry hooks so
+ * the user resolves the ambiguity. When {@link primary} is set, it names the
+ * working directory the client should auto-select before the session starts.
+ */
+export interface ISessionFolderPickerDecision {
+	/** Whether the client should hide the multi-root Folder picker. */
+	readonly hidden: boolean;
+	/**
+	 * The working directory the client should auto-select as the primary, as a
+	 * URI string. Present only when the harness pins a specific folder (it
+	 * always accompanies `hidden: true`, but a `hidden` decision need not pin
+	 * one — e.g. when no folder carries hooks the current selection is kept).
+	 */
+	readonly primary?: string;
+}
+
+/** Reads the validated folder-picker decision from session metadata. */
+export function readSessionFolderPickerDecision(meta: SessionMeta | undefined): ISessionFolderPickerDecision | undefined {
+	return validateSessionFolderPickerDecision(meta?.[SESSION_META_FOLDER_PICKER_KEY]);
+}
+
+/** Parses the validated folder-picker decision from its persisted JSON representation. */
+export function parseSessionFolderPickerDecision(value: string | undefined): ISessionFolderPickerDecision | undefined {
+	if (!value) {
+		return undefined;
+	}
+	try {
+		return validateSessionFolderPickerDecision(JSON.parse(value));
+	} catch {
+		return undefined;
+	}
+}
+
+function validateSessionFolderPickerDecision(value: unknown): ISessionFolderPickerDecision | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return undefined;
+	}
+	const raw = value as Record<string, unknown>;
+	if (typeof raw['hidden'] !== 'boolean') {
+		return undefined;
+	}
+	const primary = raw['primary'];
+	if (primary !== undefined && (typeof primary !== 'string' || primary.length === 0)) {
+		return undefined;
+	}
+	return primary !== undefined ? { hidden: raw['hidden'], primary } : { hidden: raw['hidden'] };
+}
+
+/** Returns session metadata with the folder-picker decision updated or removed. */
+export function withSessionFolderPickerDecision(meta: SessionMeta | undefined, decision: ISessionFolderPickerDecision | undefined): SessionMeta | undefined {
+	const next: SessionMeta = { ...meta };
+	if (decision) {
+		next[SESSION_META_FOLDER_PICKER_KEY] = decision.primary !== undefined
+			? { hidden: decision.hidden, primary: decision.primary }
+			: { hidden: decision.hidden };
+	} else {
+		delete next[SESSION_META_FOLDER_PICKER_KEY];
+	}
+	return Object.keys(next).length > 0 ? next : undefined;
+}
+
 /**
  * Git state of a session's working directory, carried under
  * {@link SessionMeta} at {@link SESSION_META_GIT_KEY}. Used by clients to

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1328,10 +1328,14 @@ function validateSessionFolderPickerDecision(value: unknown): ISessionFolderPick
 		return undefined;
 	}
 	const primary = raw['primary'];
-	if (primary !== undefined && (typeof primary !== 'string' || primary.length === 0)) {
+	// `primary` is only valid on a hidden, pinned decision (see
+	// ISessionFolderPickerDecision); reject the contradictory `{ hidden: false,
+	// primary }` so malformed persisted/remote metadata can't make the client
+	// both reveal the picker and auto-select/recreate the session.
+	if (primary !== undefined && (typeof primary !== 'string' || primary.length === 0 || raw['hidden'] !== true)) {
 		return undefined;
 	}
-	return primary !== undefined ? { hidden: raw['hidden'], primary } : { hidden: raw['hidden'] };
+	return primary !== undefined ? { hidden: true, primary } : { hidden: raw['hidden'] };
 }
 
 /** Returns session metadata with the folder-picker decision updated or removed. */

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1785,8 +1785,10 @@ export class AgentService extends Disposable implements IAgentService {
 			// shows with a single folder — and seeded into `_meta` below.
 			workingDirectories && workingDirectories.length > 1 && !config?.fork && !config?.importConversation && provider.computeFolderPickerDecision
 				? provider.computeFolderPickerDecision(workingDirectories).catch(err => {
+					// Fail open: on an indeterminate scan error, show the picker rather
+					// than silently hiding it and pinning the default (index 0) folder.
 					this._logService.error('[AgentService] createSession: failed to compute folder-picker decision', err);
-					return undefined;
+					return { hidden: false };
 				})
 				: Promise.resolve(undefined),
 		]);

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -36,7 +36,7 @@ import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } f
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { ChangesSummary, ChatInteractivity, ChatOriginKind, MessageAttachmentKind, type ChatOrigin, type Customization, type Message, type MessageAttachment, type MessageResourceAttachment } from '../common/state/protocol/state.js';
 import type { ChatPendingMessageSetAction, ChatTurnStartedAction } from '../common/state/protocol/actions.js';
-import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SESSION_META_MULTI_ROOT_KEY, SESSION_META_SOURCE_CONTROL_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionLifecycle, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, AH_META_IS_READ_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isDefaultChatUri, isSubagentChatUri, isSubagentSession, parseChatUri, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSessionMultiRootMetadata, parseSubagentSessionUri, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionSourceControlState, readSessionWorkspaceless, withSessionExternal, withSessionGitHubState, withSessionGitState, withSessionMultiRootMetadata, withSessionSourceControlState, withSessionStatusFlag, withSessionWorkspaceless, readSessionEhcliAdoptable, type ISessionSourceControlState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn, type UsageInfo, chatStorageUri, hasReportedUsage } from '../common/state/sessionState.js';
+import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SESSION_META_MULTI_ROOT_KEY, SESSION_META_SOURCE_CONTROL_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionLifecycle, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, AH_META_IS_READ_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isDefaultChatUri, isSubagentChatUri, isSubagentSession, parseChatUri, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSessionMultiRootMetadata, parseSubagentSessionUri, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionSourceControlState, readSessionWorkspaceless, withSessionExternal, withSessionGitHubState, withSessionGitState, withSessionMultiRootMetadata, withSessionSourceControlState, withSessionStatusFlag, withSessionWorkspaceless, withSessionFolderPickerDecision, readSessionFolderPickerDecision, parseSessionFolderPickerDecision, SESSION_META_FOLDER_PICKER_KEY, readSessionEhcliAdoptable, type ISessionSourceControlState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn, type UsageInfo, chatStorageUri, hasReportedUsage } from '../common/state/sessionState.js';
 import { readToolCallMeta } from '../common/meta/agentToolCallMeta.js';
 import { IProductService } from '../../product/common/productService.js';
 import { buildBoundedSideChatSourceContext, getSideChatPartialResponse } from './agentPeerChats.js';
@@ -1393,8 +1393,8 @@ export class AgentService extends Disposable implements IAgentService {
 					const sessionStr = s.session.toString();
 					const changesetKeys = this._changesetCoordinator.getListMetadataKeys(sessionStr);
 					const metadataKeys: Record<string, true> = changesetKeys
-						? { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, ...GIT_DB_METADATA_KEYS, ...changesetKeys }
-						: { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, ...GIT_DB_METADATA_KEYS };
+						? { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [SESSION_META_FOLDER_PICKER_KEY]: true, [CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, ...GIT_DB_METADATA_KEYS, ...changesetKeys }
+						: { customTitle: true, [AH_META_IS_READ_DB_KEY]: true, [AH_META_IS_ARCHIVED_DB_KEY]: true, [AH_META_IS_DONE_DB_KEY]: true, [AH_META_WORKSPACELESS_DB_KEY]: true, [SESSION_META_MULTI_ROOT_KEY]: true, [SESSION_META_FOLDER_PICKER_KEY]: true, [CHAT_BACKING_METADATA_KEY]: true, [WORKTREE_META_REPOSITORY_ROOT]: true, ...GIT_DB_METADATA_KEYS };
 					const m = await ref.object.getMetadataObject(metadataKeys);
 					// This session is an internal peer-chat backing (e.g. a
 					// Claude peer chat's SDK session, enumerated by the agent's
@@ -1447,6 +1447,10 @@ export class AgentService extends Disposable implements IAgentService {
 					const multiRoot = parseSessionMultiRootMetadata(m[SESSION_META_MULTI_ROOT_KEY]);
 					if (multiRoot) {
 						updated = { ...updated, _meta: withSessionMultiRootMetadata(updated._meta, multiRoot) };
+					}
+					const folderPickerDecision = parseSessionFolderPickerDecision(m[SESSION_META_FOLDER_PICKER_KEY]);
+					if (folderPickerDecision) {
+						updated = { ...updated, _meta: withSessionFolderPickerDecision(updated._meta, folderPickerDecision) };
 					}
 
 					// Use the persisted root as-is to keep listing off Git; the metadata reader re-canonicalizes it on open.
@@ -1769,10 +1773,23 @@ export class AgentService extends Disposable implements IAgentService {
 		// existing `SessionCustomizationsChanged` / `SessionCustomizationUpdated`
 		// actions published by `PluginController`.
 		const defaultChat = URI.parse(buildDefaultChatUri(session));
-		const initialCustomizations = await provider.getChatCustomizations(defaultChat, this._chatContext(session, defaultChat), this._hostCustomizations(session)).catch(err => {
-			this._logService.error('[AgentService] createSession: failed to resolve initial customizations', err);
-			return undefined;
-		});
+		const workingDirectories = config?.workingDirectories;
+		const [initialCustomizations, folderPickerDecision] = await Promise.all([
+			provider.getChatCustomizations(defaultChat, this._chatContext(session, defaultChat), this._hostCustomizations(session)).catch(err => {
+				this._logService.error('[AgentService] createSession: failed to resolve initial customizations', err);
+				return undefined;
+			}),
+			// The harness owns the Folder-picker decision (it is provider-specific),
+			// derived from the ordered working-directory set. Only meaningful for a
+			// fresh (non-fork, non-import) multi-root session — the picker never
+			// shows with a single folder — and seeded into `_meta` below.
+			workingDirectories && workingDirectories.length > 1 && !config?.fork && !config?.importConversation && provider.computeFolderPickerDecision
+				? provider.computeFolderPickerDecision(workingDirectories).catch(err => {
+					this._logService.error('[AgentService] createSession: failed to compute folder-picker decision', err);
+					return undefined;
+				})
+				: Promise.resolve(undefined),
+		]);
 
 		// When forking, populate the new session's protocol state with
 		// the source session's turns so the client sees the forked history.
@@ -1852,6 +1869,14 @@ export class AgentService extends Disposable implements IAgentService {
 		if (initialCustomizations && initialCustomizations.length > 0) {
 			this._stateManager.dispatchServerAction(session.toString(), { type: ActionType.SessionCustomizationsChanged, customizations: [...initialCustomizations] });
 		}
+		// Seed the harness-owned Folder-picker decision into the session's `_meta`.
+		// Read the current `_meta` and merge synchronously (full-object replacement
+		// on the wire) so concurrent slot writers (git/prompt-cache) are preserved,
+		// and keep this out of the customizations path so a `_meta`-only change is
+		// never dropped by the customization dedup.
+		if (folderPickerDecision) {
+			this._stateManager.setSessionMeta(session.toString(), withSessionFolderPickerDecision(this._stateManager.getSessionState(session.toString())?._meta, folderPickerDecision));
+		}
 		this._serverToolHost.advertise(session.toString());
 		// Persist resolved config values for restore. Mid-session updates are
 		// persisted by `AgentSideEffects` on `SessionConfigChanged`.
@@ -1866,6 +1891,7 @@ export class AgentService extends Disposable implements IAgentService {
 			// exists; provisional sessions defer this to `_onDidMaterializeChat`.
 			this._persistWorkspaceless(session, readSessionWorkspaceless(this._stateManager.getSessionSummary(session.toString())?._meta));
 			this._persistMultiRoot(session, readSessionMultiRootMetadata(this._stateManager.getSessionSummary(session.toString())?._meta));
+			this._persistFolderPickerDecision(session, readSessionFolderPickerDecision(this._stateManager.getSessionSummary(session.toString())?._meta));
 
 			// `SessionReady` means the agent has a live SDK session. Provisional
 			// sessions defer it to {@link _onDidMaterializeChat}.
@@ -2585,6 +2611,7 @@ export class AgentService extends Disposable implements IAgentService {
 		// real on-disk database (deferred from create for provisional sessions).
 		this._persistWorkspaceless(session, readSessionWorkspaceless(summary._meta));
 		this._persistMultiRoot(session, readSessionMultiRootMetadata(summary._meta));
+		this._persistFolderPickerDecision(session, readSessionFolderPickerDecision(summary._meta));
 		// `markSessionPersisted` writes the summary into state and fires
 		// the deferred `SessionAdded` notification atomically so subscribers
 		// see consistent state through both paths.
@@ -2679,6 +2706,31 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		ref.object.setMetadata(SESSION_META_MULTI_ROOT_KEY, JSON.stringify(multiRoot)).catch(err => {
 			this._logService.warn(`[AgentService] Failed to persist multi-root metadata for ${session.toString()}: ${toErrorMessage(err)}`);
+		}).finally(() => {
+			ref.dispose();
+		});
+	}
+
+	/**
+	 * Persists the harness-owned Folder-picker decision so it survives reload as
+	 * a frozen creation-time fact: a session created with the picker hidden stays
+	 * hidden on reopen, and one created with it shown stays shown. Deferred to
+	 * {@link _onDidMaterializeChat} for provisional sessions (no DB yet at
+	 * create), mirroring {@link _persistMultiRoot}.
+	 */
+	private _persistFolderPickerDecision(session: URI, decision: ReturnType<typeof readSessionFolderPickerDecision>): void {
+		if (!decision) {
+			return;
+		}
+		let ref;
+		try {
+			ref = this._sessionDataService.openDatabase(session);
+		} catch (err) {
+			this._logService.warn(`[AgentService] Failed to open session database to persist folder-picker decision for ${session.toString()}: ${toErrorMessage(err)}`);
+			return;
+		}
+		ref.object.setMetadata(SESSION_META_FOLDER_PICKER_KEY, JSON.stringify(decision)).catch(err => {
+			this._logService.warn(`[AgentService] Failed to persist folder-picker decision for ${session.toString()}: ${toErrorMessage(err)}`);
 		}).finally(() => {
 			ref.dispose();
 		});
@@ -3807,6 +3859,7 @@ export class AgentService extends Disposable implements IAgentService {
 							configValues: true,
 							[AH_META_WORKSPACELESS_DB_KEY]: true,
 							[SESSION_META_MULTI_ROOT_KEY]: true,
+							[SESSION_META_FOLDER_PICKER_KEY]: true,
 							...GIT_DB_METADATA_KEYS,
 							...CHANGESET_DB_METADATA_KEYS,
 						});
@@ -3865,6 +3918,7 @@ export class AgentService extends Disposable implements IAgentService {
 							sessionMetadata = withSessionWorkspaceless(sessionMetadata, m[AH_META_WORKSPACELESS_DB_KEY] === 'true');
 						}
 						sessionMetadata = withSessionMultiRootMetadata(sessionMetadata, parseSessionMultiRootMetadata(m[SESSION_META_MULTI_ROOT_KEY]));
+						sessionMetadata = withSessionFolderPickerDecision(sessionMetadata, parseSessionFolderPickerDecision(m[SESSION_META_FOLDER_PICKER_KEY]));
 
 						if (m.configValues) {
 							try {

--- a/src/vs/platform/agentHost/node/claude/claudeAgent.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgent.ts
@@ -33,7 +33,10 @@ import { ActionType } from '../../common/state/sessionActions.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
 import { AHP_AUTH_REQUIRED, ProtocolError } from '../../common/state/sessionProtocol.js';
 import { PolicyState, ProtectedResourceMetadata, type AgentSelection, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
-import { buildDefaultChatUri, ChatInputResponseKind, isDefaultChatUri, parseRequiredSessionUriFromChatUri, type ClientPluginCustomization, type Customization, type MessageAttachment, type PendingMessage, type ChatInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, ChatInputResponseKind, isDefaultChatUri, parseRequiredSessionUriFromChatUri, type ClientPluginCustomization, type Customization, type ISessionFolderPickerDecision, type MessageAttachment, type PendingMessage, type ChatInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
+import { IFileService } from '../../../files/common/files.js';
+import { computeFolderPickerDecisionForRoots } from '../shared/folderPickerDecision.js';
+import { claudeDirectoryQualifiesForPrimary } from './claudeFolderPickerCriteria.js';
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { IAgentHostGitHubEndpointService } from '../agentHostGitHubEndpointService.js';
 import { IAgentHostGitService } from '../../common/agentHostGitService.js';
@@ -609,6 +612,7 @@ export class ClaudeAgent extends Disposable implements IAgent {
 		@IAgentPluginManager private readonly _pluginManager: IAgentPluginManager,
 		@IProductService private readonly _productService: IProductService,
 		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
+		@IFileService private readonly _fileService: IFileService,
 	) {
 		super();
 		this._metadataStore = _instantiationService.createInstance(ClaudeSessionMetadataStore);
@@ -2561,6 +2565,22 @@ export class ClaudeAgent extends Disposable implements IAgent {
 			sess.setHostCustomizations(hostCustomizations);
 		}
 		return sess.getSessionCustomizations();
+	}
+
+	/**
+	 * Hides the multi-root Folder picker unless several working directories carry
+	 * Claude configuration that would pin them as the primary — an `.mcp.json`
+	 * manifest or a non-empty `hooks` block in `.claude/settings.json` /
+	 * `settings.local.json` (see {@link claudeDirectoryQualifiesForPrimary}). With
+	 * one qualifying directory it pins that folder; with several it shows the
+	 * picker so the user chooses. This only reads files to decide the picker — it
+	 * never surfaces them as customizations.
+	 */
+	async computeFolderPickerDecision(workingDirectories: readonly URI[], token: CancellationToken = CancellationToken.None): Promise<ISessionFolderPickerDecision | undefined> {
+		if (!this._isMultiRootEnabled()) {
+			return undefined;
+		}
+		return computeFolderPickerDecisionForRoots(workingDirectories, (directory, t) => claudeDirectoryQualifiesForPrimary(this._fileService, directory, this._environmentService.userHome, t), token);
 	}
 
 	async startMcpServer(session: URI, id: string): Promise<void> {

--- a/src/vs/platform/agentHost/node/claude/claudeFolderPickerCriteria.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeFolderPickerCriteria.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createCancelablePromise, firstParallel } from '../../../../base/common/async.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { joinPath } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IFileService } from '../../../files/common/files.js';
+import { parseHooksJson, readJsonFile } from '../../../agentPlugins/common/pluginParsers.js';
+
+/**
+ * Whether a Claude working directory carries configuration that pins it as the
+ * multi-root primary — used only to decide the Folder picker, never to surface
+ * customizations.
+ *
+ * A directory qualifies when it declares MCP servers or hooks:
+ * - `<dir>/.mcp.json` exists (a dedicated MCP manifest — presence is enough); or
+ * - `<dir>/.claude/settings.json` or `settings.local.json` declares a **non-empty**
+ *   `hooks` block. These are general settings files, so their mere presence is not
+ *   enough; the JSON is parsed with the same {@link parseHooksJson} rules Claude
+ *   discovery uses (honoring `disableAllHooks`), and the directory qualifies only
+ *   when at least one real hook group results.
+ *
+ * The probes run in parallel and the first that qualifies wins, cancelling the
+ * rest; a cancelled {@link token} aborts them all. Missing or unreadable files
+ * count as "not qualifying".
+ */
+export async function claudeDirectoryQualifiesForPrimary(fileService: IFileService, workingDirectory: URI, userHome: URI, token: CancellationToken = CancellationToken.None): Promise<boolean> {
+	const probes: Array<() => Promise<boolean>> = [
+		() => fileService.exists(joinPath(workingDirectory, '.mcp.json')),
+		...['settings.json', 'settings.local.json'].map(fileName => {
+			const uri = joinPath(workingDirectory, '.claude', fileName);
+			return async (): Promise<boolean> => {
+				const json = await readJsonFile(uri, fileService);
+				return json !== undefined && parseHooksJson(uri, json, workingDirectory, userHome).length > 0;
+			};
+		}),
+	];
+	const running = probes.map(probe => createCancelablePromise(() => probe()));
+	const abort = token.onCancellationRequested(() => running.forEach(probe => probe.cancel()));
+	try {
+		return (await firstParallel(running, qualifies => qualifies, false)) ?? false;
+	} finally {
+		abort.dispose();
+	}
+}

--- a/src/vs/platform/agentHost/node/codex/codexAgent.ts
+++ b/src/vs/platform/agentHost/node/codex/codexAgent.ts
@@ -35,7 +35,7 @@ import { ActionType, isChatAction, type SessionAction, type ChatAction } from '.
 import { parseLeadingSlashCommand } from '../../common/agentHostSlashCommand.js';
 import type { ConfigSchema, ModelSelection, ProtectedResourceMetadata, ToolDefinition, AgentSelection } from '../../common/state/protocol/state.js';
 import type { ResolveSessionConfigResult, SessionConfigCompletionsResult } from '../../common/state/protocol/commands.js';
-import { buildDefaultChatUri, isDefaultChatUri, parseRequiredSessionUriFromChatUri, withSessionWorkspaceless, CustomizationType, type ClientPluginCustomization, type DirectoryCustomization, type McpServerCustomization, type MessageAttachment, type PendingMessage, type ChatInputAnswer, ChatInputResponseKind, type PolicyState, type ToolCallResult, ToolResultContentType, type Turn, ResponsePartKind } from '../../common/state/sessionState.js';
+import { buildDefaultChatUri, isDefaultChatUri, parseRequiredSessionUriFromChatUri, withSessionWorkspaceless, CustomizationType, type ClientPluginCustomization, type DirectoryCustomization, type ISessionFolderPickerDecision, type McpServerCustomization, type MessageAttachment, type PendingMessage, type ChatInputAnswer, ChatInputResponseKind, type PolicyState, type ToolCallResult, ToolResultContentType, type Turn, ResponsePartKind } from '../../common/state/sessionState.js';
 import type { IAgentServerToolHost } from '../../common/agentServerTools.js';
 import { ActiveClientToolSet } from '../activeClientState.js';
 import { McpCustomizationController } from '../shared/mcpCustomizationController.js';
@@ -50,6 +50,8 @@ import { McpAuthRequiredReason, McpServerStatus, type AhpMcpUiHostCapabilities, 
 import { IAgentConfigurationService } from '../agentConfigurationService.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
 import { FileOperationResult, IFileService, toFileOperationResult } from '../../../files/common/files.js';
+import { computeFolderPickerDecisionForRoots } from '../shared/folderPickerDecision.js';
+import { codexDirectoryHasHooks } from './codexFolderPickerCriteria.js';
 import { INativeEnvironmentService } from '../../../environment/common/environment.js';
 import { IAgentPluginManager, type ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { parsePlugin } from '../../../agentPlugins/common/pluginParsers.js';
@@ -3138,6 +3140,20 @@ export class CodexAgent extends Disposable implements IAgent {
 
 	private _isMultiRootEnabled(): boolean {
 		return this._configurationService.getRootValue(platformRootSchema, AgentHostCodexMultiRootEnabledConfigKey) === true;
+	}
+
+	/**
+	 * Hides the multi-root Folder picker unless several working directories carry
+	 * a Codex `.codex/hooks.json` hook manifest (see
+	 * {@link codexDirectoryHasHooks}). With one qualifying directory it pins that
+	 * folder; with several it shows the picker so the user chooses. This only
+	 * reads files to decide the picker — it never surfaces them as customizations.
+	 */
+	async computeFolderPickerDecision(workingDirectories: readonly URI[], token: CancellationToken = CancellationToken.None): Promise<ISessionFolderPickerDecision | undefined> {
+		if (!this._isMultiRootEnabled()) {
+			return undefined;
+		}
+		return computeFolderPickerDecisionForRoots(workingDirectories, (directory, t) => codexDirectoryHasHooks(this._fileService, directory, t), token);
 	}
 
 	/**

--- a/src/vs/platform/agentHost/node/codex/codexFolderPickerCriteria.ts
+++ b/src/vs/platform/agentHost/node/codex/codexFolderPickerCriteria.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { joinPath } from '../../../../base/common/resources.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IFileService } from '../../../files/common/files.js';
+
+/**
+ * Whether a Codex working directory carries hooks that pin it as the multi-root
+ * primary — used only to decide the Folder picker, never to surface
+ * customizations.
+ *
+ * Codex reads hooks from a dedicated `<dir>/.codex/hooks.json` manifest, so its
+ * presence is the signal. Missing or unreadable files count as "not qualifying".
+ */
+export async function codexDirectoryHasHooks(fileService: IFileService, workingDirectory: URI, _token: CancellationToken = CancellationToken.None): Promise<boolean> {
+	return fileService.exists(joinPath(workingDirectory, '.codex', 'hooks.json'));
+}

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import { pathToFileURL } from 'url';
 import { CancelablePromise, createCancelablePromise, DeferredPromise, Delayer, disposableTimeout, Limiter, raceTimeout, Sequencer, SequencerByKey } from '../../../../base/common/async.js';
-import { type CancellationToken } from '../../../../base/common/cancellation.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { structuralEquals } from '../../../../base/common/equals.js';
 import { CancellationError, getErrorMessage } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
@@ -57,7 +57,7 @@ import type { ErrorInfo } from '../../common/state/protocol/common/state.js';
 import { ProtectedResourceMetadata, type AgentSelection, type ChildCustomizationType, type ConfigPropertySchema, type ConfigSchema, type CustomizationEnablement, type ModelSelection, type ToolDefinition } from '../../common/state/protocol/state.js';
 import { ActionType, AuthRequiredReason, type AuthRequiredParams, type SessionAction } from '../../common/state/sessionActions.js';
 import { areAdditionalWorkingDirectoriesEqual } from '../../common/state/sessionWorkingDirectories.js';
-import { AgentCustomization, CustomizationLoadStatus, CustomizationType, RuleCustomization, ChatInputResponseKind, SkillCustomization, customizationId, buildChatUri, buildDefaultChatUri, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_READ_DB_KEY, isDefaultChatUri, withSessionEhcliAdoptable, type ChildCustomization, type ClientPluginCustomization, type Customization, type DirectoryCustomization, type HookCustomization, type MessageAttachment, type PendingMessage, type PluginCustomization, type PolicyState, type ChatInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
+import { AgentCustomization, CustomizationLoadStatus, CustomizationType, RuleCustomization, ChatInputResponseKind, SkillCustomization, customizationId, buildChatUri, buildDefaultChatUri, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_READ_DB_KEY, isDefaultChatUri, withSessionEhcliAdoptable, type ChildCustomization, type ClientPluginCustomization, type Customization, type DirectoryCustomization, type HookCustomization, type ISessionFolderPickerDecision, type MessageAttachment, type PendingMessage, type PluginCustomization, type PolicyState, type ChatInputAnswer, type ToolCallResult, type Turn } from '../../common/state/sessionState.js';
 import { getByokLmAgentModelId } from '../../common/agentHostByokLm.js';
 import { isCustomizationEnabled } from '../../common/customizationEnablement.js';
 import { ActiveClientToolSet, structuralToolsEqual } from '../activeClientState.js';
@@ -86,7 +86,8 @@ import { ICopilotApiService, type IRestrictedTelemetryContext } from '../shared/
 import { AgentHostGitHubTelemetryRouter } from '../agentHostGitHubTelemetryRouter.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
 import { CopilotSlashCommandCompletionProvider, ICopilotRuntimeSlashCommandQueryOptions } from './copilotSlashCommandCompletionProvider.js';
-import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectoriesEqual, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
+import { DiscoveredType, SessionCustomizationDiscovery, areDiscoveredDirectoriesEqual, workspaceDirectoryHasHooks, type IDiscoveredDirectory } from './sessionCustomizationDiscovery.js';
+import { computeFolderPickerDecisionForRoots } from '../shared/folderPickerDecision.js';
 import { COPILOT_INTEGRATION_ID } from '../../../endpoint/common/licenseAgreement.js';
 import { getAppNodeModulesPath } from '../appNodeModules.js';
 import { CopilotSlashCommandProvider } from './copilotSlashCommandProvider.js';
@@ -733,6 +734,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@ICopilotApiService private readonly _copilotApiService: ICopilotApiService,
 		@IAgentHostProxyResolver private readonly _proxyResolver: IAgentHostProxyResolver,
+		@IFileService private readonly _fileService: IFileService,
 	) {
 		super();
 		this._lastManagedSettingsPermissions = this._managedSettingsService.permissions;
@@ -1213,6 +1215,31 @@ export class CopilotAgent extends Disposable implements IAgent {
 		);
 		const customizations = [...fromPlugins, ...topLevelMcp];
 		return applyMcpServerEnablement(customizations, this._retainedHostCustomizations(session));
+	}
+
+	/**
+	 * Copilot applies hooks from the primary working directory only (see
+	 * `_hookWorkingDirectories` in sessionCustomizationDiscovery), so in a
+	 * multi-root workspace the folder carrying hooks must be the primary. Since
+	 * only the primary's hooks run, the picker is only needed to resolve
+	 * ambiguity between folders that carry hooks:
+	 * - several working directories have hooks under `.github/hooks/` → show the
+	 *   Folder picker so the user chooses which folder's hooks lead;
+	 * - exactly one does → pin it as the primary and hide the picker;
+	 * - none do → hide the picker and leave the current selection as-is (any
+	 *   folder is a valid primary when there are no hooks to run).
+	 *
+	 * The scan is intentionally scoped to `.github/hooks/*.json` only — it does
+	 * NOT cover the `settings.json`-based hook sources discovery also recognizes
+	 * (`.github/copilot/settings.json`, `.claude/settings.json`) — and never
+	 * exposes what it finds as customizations, so what a session exposes is
+	 * unchanged.
+	 */
+	async computeFolderPickerDecision(workingDirectories: readonly URI[], token: CancellationToken = CancellationToken.None): Promise<ISessionFolderPickerDecision | undefined> {
+		if (!this._isMultiRootEnabled()) {
+			return undefined;
+		}
+		return computeFolderPickerDecisionForRoots(workingDirectories, (directory, t) => workspaceDirectoryHasHooks(this._fileService, directory, t), token);
 	}
 
 	async handleMcpRequest(session: URI, serverName: string, method: string, params: Record<string, unknown> | undefined): Promise<unknown> {

--- a/src/vs/platform/agentHost/node/copilot/sessionCustomizationDiscovery.ts
+++ b/src/vs/platform/agentHost/node/copilot/sessionCustomizationDiscovery.ts
@@ -5,7 +5,7 @@
 
 import type { CopilotClient } from '@github/copilot-sdk';
 import { appendFile, mkdir } from 'fs/promises';
-import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, type IDisposable } from '../../../../base/common/lifecycle.js';
@@ -14,7 +14,7 @@ import { joinPath, dirname as uriDirname, extUriBiasedIgnorePathCase } from '../
 import { compare as compareStrings } from '../../../../base/common/strings.js';
 import { URI } from '../../../../base/common/uri.js';
 import { basename, isAbsolute, dirname as nodeDirname } from '../../../../base/common/path.js';
-import { IFileService, IFileStatWithMetadata } from '../../../files/common/files.js';
+import { FileOperationResult, IFileService, IFileStat, IFileStatWithMetadata, toFileOperationResult } from '../../../files/common/files.js';
 import { ILogService } from '../../../log/common/log.js';
 import { AgentCustomization, ChildCustomization, CustomizationLoadStatus, CustomizationType, DirectoryCustomization, HookCustomization, RuleCustomization, SkillCustomization, customizationId } from '../../common/state/sessionState.js';
 import { ChildCustomizationType } from '../../common/state/protocol/state.js';
@@ -1211,7 +1211,76 @@ export class SessionCustomizationDiscovery extends Disposable {
 	}
 }
 
-
+/**
+ * Presence-only counterpart to {@link SessionCustomizationDiscovery}'s hook
+ * scan: resolves `true` as soon as a hook file (`*.json`) is found anywhere
+ * under `<workingDirectory>/.github/hooks/` (recursively, up to
+ * {@link MAX_HOOKS_RECURSION_DEPTH}), and `false` when the folder is missing or
+ * carries no hooks. Subdirectories at each level are scanned in parallel; the
+ * first branch to find a hook cancels the rest so no further directories are
+ * read once the answer is known. The optional {@link token} lets a caller abort
+ * the whole scan (e.g. if session creation is torn down).
+ *
+ * Errors are deliberately split: a **missing** `.github/hooks` (or subdirectory)
+ * is a definitive "no hooks here" and yields `false`, but any **other** failure
+ * (permission, transient IO) is rethrown rather than swallowed — so a caller
+ * can fail open (show the picker) instead of silently under-counting hook
+ * folders and hiding/pinning the wrong one.
+ *
+ * Scope note: this covers only the `.github/hooks/*.json` source, not the
+ * `settings.json`-based hook sources discovery also recognizes; it reuses
+ * {@link HOOK_FILE_SUFFIX} so the file-suffix stays single-sourced with
+ * discovery. It intentionally does NOT surface the hooks as customizations — it
+ * exists only to decide the multi-root Folder picker's primary — so what a
+ * session exposes as customizations is unchanged.
+ */
+export async function workspaceDirectoryHasHooks(fileService: IFileService, workingDirectory: URI, token: CancellationToken = CancellationToken.None): Promise<boolean> {
+	// Linked to the caller's token so external cancellation aborts the scan, and
+	// cancelled internally the moment a hook is found so the remaining parallel
+	// branches stop launching further reads.
+	const scanCts = new CancellationTokenSource(token);
+	let found = false;
+	const containsHook = async (directory: URI, depth: number): Promise<void> => {
+		if (scanCts.token.isCancellationRequested) {
+			return;
+		}
+		let stat: IFileStat;
+		try {
+			stat = await fileService.resolve(directory, { resolveMetadata: false });
+		} catch (err) {
+			// Ignore failures once we're winding down (a sibling already found a
+			// hook, or the caller cancelled). Otherwise treat a missing directory
+			// as "no hooks" and surface every other error so the caller fails open.
+			if (!scanCts.token.isCancellationRequested && toFileOperationResult(err as Error) !== FileOperationResult.FILE_NOT_FOUND) {
+				throw err;
+			}
+			return;
+		}
+		const children = stat.children ?? [];
+		if (children.some(child => child.isFile && child.name.toLowerCase().endsWith(HOOK_FILE_SUFFIX))) {
+			found = true;
+			scanCts.cancel();
+			return;
+		}
+		if (depth >= MAX_HOOKS_RECURSION_DEPTH) {
+			return;
+		}
+		await Promise.all(children
+			.filter(child => child.isDirectory)
+			.map(child => containsHook(child.resource, depth + 1)));
+	};
+	try {
+		await containsHook(joinPath(workingDirectory, '.github', 'hooks'), 0);
+	} finally {
+		scanCts.dispose();
+	}
+	// A caller-cancelled scan has an unreliable result; signal it rather than
+	// reporting a (possibly premature) `false`.
+	if (token.isCancellationRequested) {
+		throw new CancellationError();
+	}
+	return found;
+}
 
 // Test-only helpers — exported as `_internal` to discourage production use.
 export const _internal = {

--- a/src/vs/platform/agentHost/node/shared/folderPickerDecision.ts
+++ b/src/vs/platform/agentHost/node/shared/folderPickerDecision.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { URI } from '../../../../base/common/uri.js';
+import { ISessionFolderPickerDecision } from '../../common/state/sessionState.js';
+
+/**
+ * Shared multi-root Folder-picker decision, expressed over a per-provider
+ * "does this working directory carry configuration that pins it as the primary"
+ * predicate. Each provider (Copilot hooks, Claude MCP/hooks, Codex hooks)
+ * supplies its own {@link hasSelectionCriteria}; the count of qualifying
+ * directories drives a single, uniform rule:
+ *
+ * - **0 qualifying** → hide the picker and keep whatever folder is selected
+ *   (`{ hidden: true }`, no primary): with nothing to pin, any folder is fine.
+ * - **exactly 1** → hide the picker and pin that folder (`{ hidden: true,
+ *   primary }`).
+ * - **2 or more** → show the picker (`{ hidden: false }`) so the user resolves
+ *   which folder's configuration should lead.
+ *
+ * Returns `undefined` for a single working directory (the picker never applies),
+ * so callers can seed "no decision" for non-multi-root sessions.
+ *
+ * The predicate is run for every working directory in parallel; the provider is
+ * responsible for how it treats missing/unreadable directories.
+ */
+export async function computeFolderPickerDecisionForRoots(
+	workingDirectories: readonly URI[],
+	hasSelectionCriteria: (workingDirectory: URI, token: CancellationToken) => Promise<boolean>,
+	token: CancellationToken = CancellationToken.None,
+): Promise<ISessionFolderPickerDecision | undefined> {
+	if (workingDirectories.length <= 1) {
+		return undefined;
+	}
+	const results = await Promise.all(workingDirectories.map(directory => hasSelectionCriteria(directory, token)));
+	const qualifying = workingDirectories.filter((_, index) => results[index]);
+	if (qualifying.length >= 2) {
+		return { hidden: false };
+	}
+	if (qualifying.length === 1) {
+		return { hidden: true, primary: qualifying[0].toString() };
+	}
+	return { hidden: true };
+}

--- a/src/vs/platform/agentHost/test/common/sessionFolderPickerMeta.test.ts
+++ b/src/vs/platform/agentHost/test/common/sessionFolderPickerMeta.test.ts
@@ -19,6 +19,7 @@ suite('Session folder-picker meta', () => {
 			hiddenWithPrimary: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: true, primary: 'file:///wsB' } }),
 			nonBooleanHidden: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: 'yes' } }),
 			emptyPrimary: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: true, primary: '' } }),
+			shownWithPrimary: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: false, primary: 'file:///wsB' } }),
 			notAnObject: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: 'nope' }),
 		}, {
 			absent: undefined,
@@ -27,6 +28,7 @@ suite('Session folder-picker meta', () => {
 			hiddenWithPrimary: { hidden: true, primary: 'file:///wsB' },
 			nonBooleanHidden: undefined,
 			emptyPrimary: undefined,
+			shownWithPrimary: undefined,
 			notAnObject: undefined,
 		});
 	});
@@ -56,6 +58,7 @@ suite('Session folder-picker meta', () => {
 			absent: parseSessionFolderPickerDecision(undefined),
 			malformedJson: parseSessionFolderPickerDecision('{'),
 			malformedShape: parseSessionFolderPickerDecision(JSON.stringify({ hidden: 'yes' })),
+			shownWithPrimary: parseSessionFolderPickerDecision(JSON.stringify({ hidden: false, primary: 'file:///wsB' })),
 		}, {
 			hidden: { hidden: true },
 			hiddenWithPrimary: { hidden: true, primary: 'file:///wsB' },
@@ -63,6 +66,7 @@ suite('Session folder-picker meta', () => {
 			absent: undefined,
 			malformedJson: undefined,
 			malformedShape: undefined,
+			shownWithPrimary: undefined,
 		});
 	});
 });

--- a/src/vs/platform/agentHost/test/common/sessionFolderPickerMeta.test.ts
+++ b/src/vs/platform/agentHost/test/common/sessionFolderPickerMeta.test.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { parseSessionFolderPickerDecision, readSessionFolderPickerDecision, SESSION_META_FOLDER_PICKER_KEY, withSessionFolderPickerDecision, withSessionGitHubState } from '../../common/state/sessionState.js';
+
+suite('Session folder-picker meta', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('reads validated decisions and rejects malformed ones', () => {
+		assert.deepStrictEqual({
+			absent: readSessionFolderPickerDecision(undefined),
+			empty: readSessionFolderPickerDecision({}),
+			shown: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: false } }),
+			hiddenWithPrimary: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: true, primary: 'file:///wsB' } }),
+			nonBooleanHidden: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: 'yes' } }),
+			emptyPrimary: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: true, primary: '' } }),
+			notAnObject: readSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: 'nope' }),
+		}, {
+			absent: undefined,
+			empty: undefined,
+			shown: { hidden: false },
+			hiddenWithPrimary: { hidden: true, primary: 'file:///wsB' },
+			nonBooleanHidden: undefined,
+			emptyPrimary: undefined,
+			notAnObject: undefined,
+		});
+	});
+
+	test('round-trips the decision, preserves other slots, and clears to undefined', () => {
+		const withOther = withSessionGitHubState(undefined, { owner: 'octo' });
+		const tagged = withSessionFolderPickerDecision(withOther, { hidden: true, primary: 'file:///wsB' });
+
+		assert.deepStrictEqual({
+			decision: readSessionFolderPickerDecision(tagged),
+			otherSlotPreserved: tagged?.['github'],
+			cleared: withSessionFolderPickerDecision(tagged, undefined)?.[SESSION_META_FOLDER_PICKER_KEY],
+			collapsesToUndefined: withSessionFolderPickerDecision({ [SESSION_META_FOLDER_PICKER_KEY]: { hidden: true } }, undefined),
+		}, {
+			decision: { hidden: true, primary: 'file:///wsB' },
+			otherSlotPreserved: { owner: 'octo' },
+			cleared: undefined,
+			collapsesToUndefined: undefined,
+		});
+	});
+
+	test('survives the persisted DB string round-trip and rejects malformed JSON', () => {
+		assert.deepStrictEqual({
+			hidden: parseSessionFolderPickerDecision(JSON.stringify({ hidden: true })),
+			hiddenWithPrimary: parseSessionFolderPickerDecision(JSON.stringify({ hidden: true, primary: 'file:///wsB' })),
+			shown: parseSessionFolderPickerDecision(JSON.stringify({ hidden: false })),
+			absent: parseSessionFolderPickerDecision(undefined),
+			malformedJson: parseSessionFolderPickerDecision('{'),
+			malformedShape: parseSessionFolderPickerDecision(JSON.stringify({ hidden: 'yes' })),
+		}, {
+			hidden: { hidden: true },
+			hiddenWithPrimary: { hidden: true, primary: 'file:///wsB' },
+			shown: { hidden: false },
+			absent: undefined,
+			malformedJson: undefined,
+			malformedShape: undefined,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -822,6 +822,10 @@ suite('AgentService (node dispatcher)', () => {
 
 	test('createSession fails open (shows the picker) when the folder-picker decision rejects', async () => {
 		class RejectingFolderPickerAgent extends MockAgent {
+			override getDescriptor() {
+				const base = super.getDescriptor();
+				return { ...base, capabilities: { ...base.capabilities, multipleWorkingDirectories: { immutablePrimary: true } } };
+			}
 			computeFolderPickerDecision(): Promise<ISessionFolderPickerDecision | undefined> {
 				return Promise.reject(new Error('scan failed'));
 			}
@@ -844,6 +848,10 @@ suite('AgentService (node dispatcher)', () => {
 
 	test('createSession seeds the harness-pinned folder-picker decision into session metadata', async () => {
 		class PinningFolderPickerAgent extends MockAgent {
+			override getDescriptor() {
+				const base = super.getDescriptor();
+				return { ...base, capabilities: { ...base.capabilities, multipleWorkingDirectories: { immutablePrimary: true } } };
+			}
 			computeFolderPickerDecision(workingDirectories: readonly URI[]): Promise<ISessionFolderPickerDecision | undefined> {
 				return Promise.resolve({ hidden: true, primary: workingDirectories[1].toString() });
 			}

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -38,7 +38,7 @@ import { META_GITHUB_STATE, META_SOURCE_CONTROL_STATE } from '../../common/agent
 import { SessionConfigKey } from '../../common/sessionConfigKeys.js';
 import { SessionDatabase } from '../../node/sessionDatabase.js';
 import { ActionType, ActionEnvelope, NotificationType } from '../../common/state/sessionActions.js';
-import { AH_META_WORKSPACELESS_DB_KEY, ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isDefaultChatUri, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionEhcliAdoptable, readSessionExternal, readSessionGitHubState, readSessionMultiRootMetadata, readSessionSourceControlState, withSessionEhcliAdoptable, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionWithDefaultChat, type MarkdownResponsePart, type SessionState, type SessionSummary, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
+import { AH_META_WORKSPACELESS_DB_KEY, ChangesetStatus, CustomizationType, MessageAttachmentKind, MessageKind, SessionActiveClient, ResponsePartKind, ROOT_STATE_URI, SESSION_META_MULTI_ROOT_KEY, SessionLifecycle, SessionSourceControlOutcome, SessionStatus, ToolCallCancellationReason, ToolCallConfirmationReason, ToolCallStatus, ToolResultContentType, TurnState, buildChatUri, buildDefaultChatUri, buildSubagentChatUri, buildSubagentSessionUri, customizationId, isDefaultChatUri, isSubagentSession, parseChatUri, parseSubagentSessionUri, readSessionEhcliAdoptable, readSessionExternal, readSessionGitHubState, readSessionMultiRootMetadata, readSessionFolderPickerDecision, readSessionSourceControlState, withSessionEhcliAdoptable, withSessionMultiRootMetadata, ChatOriginKind, type ChangesetState, type ISessionFolderPickerDecision, type ISessionWithDefaultChat, type MarkdownResponsePart, type SessionState, type SessionSummary, type ToolCallCompletedState, type ToolCallResponsePart, type Turn } from '../../common/state/sessionState.js';
 import { ChatInteractivity, type MessageAttachment } from '../../common/state/protocol/state.js';
 import { IProductService } from '../../../product/common/productService.js';
 import { AgentService } from '../../node/agentService.js';
@@ -818,6 +818,50 @@ suite('AgentService (node dispatcher)', () => {
 			inherited: multiRoot,
 			overridden: override,
 		});
+	});
+
+	test('createSession fails open (shows the picker) when the folder-picker decision rejects', async () => {
+		class RejectingFolderPickerAgent extends MockAgent {
+			computeFolderPickerDecision(): Promise<ISessionFolderPickerDecision | undefined> {
+				return Promise.reject(new Error('scan failed'));
+			}
+		}
+		const agent = new RejectingFolderPickerAgent('copilot');
+		disposables.add(toDisposable(() => agent.dispose()));
+		const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+		localService.registerProvider(agent);
+
+		const session = await localService.createSession({
+			provider: agent.id,
+			workingDirectories: [URI.file('/workspace/one'), URI.file('/workspace/two')],
+		});
+
+		assert.deepStrictEqual(
+			readSessionFolderPickerDecision(localService.stateManager.getSessionState(session.toString())?._meta),
+			{ hidden: false },
+		);
+	});
+
+	test('createSession seeds the harness-pinned folder-picker decision into session metadata', async () => {
+		class PinningFolderPickerAgent extends MockAgent {
+			computeFolderPickerDecision(workingDirectories: readonly URI[]): Promise<ISessionFolderPickerDecision | undefined> {
+				return Promise.resolve({ hidden: true, primary: workingDirectories[1].toString() });
+			}
+		}
+		const agent = new PinningFolderPickerAgent('copilot');
+		disposables.add(toDisposable(() => agent.dispose()));
+		const localService = disposables.add(new AgentService(new NullLogService(), fileService, createSessionDataService(), { _serviceBrand: undefined } as IProductService, createNoopGitService()));
+		localService.registerProvider(agent);
+
+		const session = await localService.createSession({
+			provider: agent.id,
+			workingDirectories: [URI.file('/workspace/one'), URI.file('/workspace/two')],
+		});
+
+		assert.deepStrictEqual(
+			readSessionFolderPickerDecision(localService.stateManager.getSessionState(session.toString())?._meta),
+			{ hidden: true, primary: URI.file('/workspace/two').toString() },
+		);
 	});
 
 	test('provisional materialization preserves and persists multi-root metadata', async () => {

--- a/src/vs/platform/agentHost/test/node/codex/codexFolderPickerCriteria.test.ts
+++ b/src/vs/platform/agentHost/test/node/codex/codexFolderPickerCriteria.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { FileService } from '../../../../files/common/fileService.js';
+import { IFileService } from '../../../../files/common/files.js';
+import { InMemoryFileSystemProvider } from '../../../../files/common/inMemoryFilesystemProvider.js';
+import { NullLogService } from '../../../../log/common/log.js';
+import { codexDirectoryHasHooks } from '../../../node/codex/codexFolderPickerCriteria.js';
+
+suite('codexDirectoryHasHooks', () => {
+
+	const disposables = new DisposableStore();
+	let fileService: IFileService;
+
+	setup(() => {
+		fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const has = (path: string) => codexDirectoryHasHooks(fileService, URI.from({ scheme: Schemas.inMemory, path }));
+
+	test('qualifies only when a .codex/hooks.json manifest is present', async () => {
+		await fileService.writeFile(URI.from({ scheme: Schemas.inMemory, path: '/withHooks/.codex/hooks.json' }), VSBuffer.fromString('{}'));
+		await fileService.writeFile(URI.from({ scheme: Schemas.inMemory, path: '/otherFile/.codex/config.json' }), VSBuffer.fromString('{}'));
+
+		assert.deepStrictEqual({
+			present: await has('/withHooks'),
+			otherFileOnly: await has('/otherFile'),
+			missing: await has('/nothing'),
+		}, {
+			present: true,
+			otherFileOnly: false,
+			missing: false,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -701,8 +701,9 @@ class ResumePathCopilotAgent extends CopilotAgent {
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IAgentHostProxyResolver proxyResolver: IAgentHostProxyResolver,
 		@ICopilotApiService copilotApiService: ICopilotApiService,
+		@IFileService fileService: IFileService,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, sessionTitleSignal, managedSettingsService, createTestGitHubEndpointService(), otelService, completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, customizationEnablementService, environmentService, byokBridgeRegistry, telemetryService, copilotApiService, proxyResolver);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, sessionTitleSignal, managedSettingsService, createTestGitHubEndpointService(), otelService, completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, customizationEnablementService, environmentService, byokBridgeRegistry, telemetryService, copilotApiService, proxyResolver, fileService);
 	}
 
 	protected override _createCopilotClient(): CopilotClient {
@@ -737,8 +738,9 @@ class TestableCopilotAgent extends CopilotAgent {
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IAgentHostProxyResolver proxyResolver: IAgentHostProxyResolver,
 		@ICopilotApiService copilotApiService: ICopilotApiService,
+		@IFileService fileService: IFileService,
 	) {
-		super(logService, instantiationService, sessionDataService, gitService, configurationService, sessionTitleSignal, managedSettingsService, createTestGitHubEndpointService(), otelService, completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, customizationEnablementService, environmentService, byokBridgeRegistry, telemetryService, copilotApiService, proxyResolver);
+		super(logService, instantiationService, sessionDataService, gitService, configurationService, sessionTitleSignal, managedSettingsService, createTestGitHubEndpointService(), otelService, completions, NULL_CHECKPOINT_SERVICE, NULL_REVIEW_SERVICE, customizationEnablementService, environmentService, byokBridgeRegistry, telemetryService, copilotApiService, proxyResolver, fileService);
 	}
 
 	protected override _createCopilotClient(options: CopilotClientOptions): CopilotClient {
@@ -1229,6 +1231,41 @@ suite('CopilotAgent', () => {
 				disabledByDefault: undefined,
 				whenEnabled: { immutablePrimary: true },
 				afterDisabling: undefined,
+			});
+		} finally {
+			await disposeAgent(agent);
+		}
+	});
+
+	test('computeFolderPickerDecision hides the picker unless multiple folders carry .github/hooks', async () => {
+		const fileService = disposables.add(new FileService(new NullLogService()));
+		disposables.add(fileService.registerProvider(Schemas.inMemory, disposables.add(new InMemoryFileSystemProvider())));
+		const folder = (name: string) => URI.from({ scheme: Schemas.inMemory, path: `/${name}` });
+		const seedHook = (name: string, file = 'hook.json') => fileService.writeFile(URI.joinPath(folder(name), '.github', 'hooks', file), VSBuffer.fromString('{}'));
+		const [a, b, c] = [folder('wsA'), folder('wsB'), folder('wsC')];
+
+		const { agent, stateManager } = createTestAgentContext(disposables, { fileService });
+		try {
+			stateManager.dispatchServerAction(ROOT_STATE_URI, { type: ActionType.RootConfigChanged, config: { [AgentHostCopilotMultiRootEnabledConfigKey]: true } });
+
+			await seedHook('wsB');
+			const soleHookFolder = await agent.computeFolderPickerDecision([a, b, c]);
+
+			await seedHook('wsA', 'nested/other.json');
+			const multipleHookFolders = await agent.computeFolderPickerDecision([a, b, c]);
+
+			const noHookFolders = await agent.computeFolderPickerDecision([folder('wsX'), folder('wsY')]);
+			const singleWorkingDirectory = await agent.computeFolderPickerDecision([b]);
+
+			stateManager.dispatchServerAction(ROOT_STATE_URI, { type: ActionType.RootConfigChanged, config: { [AgentHostCopilotMultiRootEnabledConfigKey]: false } });
+			const multiRootDisabled = await agent.computeFolderPickerDecision([a, b, c]);
+
+			assert.deepStrictEqual({ soleHookFolder, multipleHookFolders, noHookFolders, singleWorkingDirectory, multiRootDisabled }, {
+				soleHookFolder: { hidden: true, primary: b.toString() },
+				multipleHookFolders: { hidden: false },
+				noHookFolders: { hidden: true },
+				singleWorkingDirectory: undefined,
+				multiRootDisabled: undefined,
 			});
 		} finally {
 			await disposeAgent(agent);

--- a/src/vs/platform/agentHost/test/node/customizations/claudeFolderPickerCriteria.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/claudeFolderPickerCriteria.test.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IFileService } from '../../../../files/common/files.js';
+import { claudeDirectoryQualifiesForPrimary } from '../../../node/claude/claudeFolderPickerCriteria.js';
+import { createInMemoryFileService, seedFile } from './claudeCustomizationTestUtils.js';
+
+suite('claudeDirectoryQualifiesForPrimary', () => {
+
+	const disposables = new DisposableStore();
+	let fileService: IFileService;
+	const userHome = URI.from({ scheme: Schemas.inMemory, path: '/home' });
+	const hooks = JSON.stringify({ hooks: { PostToolUse: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] } });
+
+	setup(() => {
+		fileService = createInMemoryFileService(disposables);
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const qualifies = (path: string) => claudeDirectoryQualifiesForPrimary(fileService, URI.from({ scheme: Schemas.inMemory, path }), userHome);
+
+	test('qualifies on an .mcp.json manifest or a non-empty hooks block, and ignores empty/disabled hooks', async () => {
+		await seedFile(fileService, '/mcp/.mcp.json', '{}');
+		await seedFile(fileService, '/settings/.claude/settings.json', hooks);
+		await seedFile(fileService, '/local/.claude/settings.local.json', hooks);
+		await seedFile(fileService, '/emptyHooks/.claude/settings.json', JSON.stringify({ hooks: {} }));
+		await seedFile(fileService, '/disabled/.claude/settings.json', JSON.stringify({ disableAllHooks: true, hooks: { PostToolUse: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] } }));
+		await seedFile(fileService, '/unrelated/.claude/settings.json', JSON.stringify({ model: 'claude-x' }));
+
+		assert.deepStrictEqual({
+			mcpOnly: await qualifies('/mcp'),
+			settingsHooks: await qualifies('/settings'),
+			localSettingsHooks: await qualifies('/local'),
+			emptyHooks: await qualifies('/emptyHooks'),
+			disabledHooks: await qualifies('/disabled'),
+			unrelatedSettings: await qualifies('/unrelated'),
+			nothing: await qualifies('/nothing'),
+		}, {
+			mcpOnly: true,
+			settingsHooks: true,
+			localSettingsHooks: true,
+			emptyHooks: false,
+			disabledHooks: false,
+			unrelatedSettings: false,
+			nothing: false,
+		});
+	});
+});

--- a/src/vs/platform/agentHost/test/node/customizations/workspaceDirectoryHasHooks.test.ts
+++ b/src/vs/platform/agentHost/test/node/customizations/workspaceDirectoryHasHooks.test.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { CancellationError } from '../../../../../base/common/errors.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { FileOperationError, FileOperationResult, IFileService, IFileStatWithMetadata } from '../../../../files/common/files.js';
+import { workspaceDirectoryHasHooks } from '../../../node/copilot/sessionCustomizationDiscovery.js';
+import { createInMemoryFileService, seedFile } from './claudeCustomizationTestUtils.js';
+
+suite('workspaceDirectoryHasHooks', () => {
+
+	const disposables = new DisposableStore();
+	let fileService: IFileService;
+	const workspace = URI.from({ scheme: Schemas.inMemory, path: '/ws' });
+
+	setup(() => {
+		fileService = createInMemoryFileService(disposables);
+	});
+
+	teardown(() => {
+		disposables.clear();
+	});
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('detects hooks by presence and location, ignoring non-JSON and respecting the depth cap', async () => {
+		// The scan root is `<workspace>/.github/hooks` (depth 0). Directory `8` sits
+		// at depth 8 — the deepest whose files are scanned — while directory `9`
+		// (depth 9) is never reached.
+		await seedFile(fileService, '/ws/topLevel/.github/hooks/hook.json', '{}');
+		await seedFile(fileService, '/ws/upper/.github/hooks/HOOK.JSON', '{}');
+		await seedFile(fileService, '/ws/nonJson/.github/hooks/hook.txt', 'not a hook');
+		await seedFile(fileService, '/ws/deep/.github/hooks/1/2/3/4/5/6/7/8/hook.json', '{}');            // depth 8 → found
+		await seedFile(fileService, '/ws/tooDeep/.github/hooks/1/2/3/4/5/6/7/8/9/hook.json', '{}');       // depth 9 → not found
+
+		const has = (path: string) => workspaceDirectoryHasHooks(fileService, URI.from({ scheme: Schemas.inMemory, path }));
+		assert.deepStrictEqual({
+			missing: await workspaceDirectoryHasHooks(fileService, workspace),
+			topLevel: await has('/ws/topLevel'),
+			caseInsensitive: await has('/ws/upper'),
+			nonJsonIgnored: await has('/ws/nonJson'),
+			atDepthCap: await has('/ws/deep'),
+			beyondDepthCap: await has('/ws/tooDeep'),
+		}, {
+			missing: false,
+			topLevel: true,
+			caseInsensitive: true,
+			nonJsonIgnored: false,
+			atDepthCap: true,
+			beyondDepthCap: false,
+		});
+	});
+
+	test('rethrows non-not-found errors so the caller can fail open', async () => {
+		const throwingFileService = new class extends mock<IFileService>() {
+			override async resolve(): Promise<IFileStatWithMetadata> {
+				throw new FileOperationError('permission denied', FileOperationResult.FILE_PERMISSION_DENIED);
+			}
+		};
+
+		await assert.rejects(workspaceDirectoryHasHooks(throwingFileService, workspace));
+	});
+
+	test('throws a CancellationError when the caller cancels the scan', async () => {
+		await assert.rejects(
+			workspaceDirectoryHasHooks(fileService, workspace, CancellationToken.Cancelled),
+			err => err instanceof CancellationError,
+		);
+	});
+});

--- a/src/vs/platform/agentHost/test/node/shared/folderPickerDecision.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/folderPickerDecision.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { computeFolderPickerDecisionForRoots } from '../../../node/shared/folderPickerDecision.js';
+
+suite('computeFolderPickerDecisionForRoots', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const folder = (name: string) => URI.from({ scheme: Schemas.inMemory, path: `/${name}` });
+	const [a, b, c] = [folder('a'), folder('b'), folder('c')];
+	const qualifies = (set: readonly URI[]) => (dir: URI) => Promise.resolve(set.some(q => q.toString() === dir.toString()));
+
+	test('maps the qualifying-folder count to hide / pin / show', async () => {
+		assert.deepStrictEqual({
+			none: await computeFolderPickerDecisionForRoots([a, b, c], qualifies([])),
+			one: await computeFolderPickerDecisionForRoots([a, b, c], qualifies([b])),
+			several: await computeFolderPickerDecisionForRoots([a, b, c], qualifies([a, c])),
+			singleRoot: await computeFolderPickerDecisionForRoots([b], qualifies([b])),
+		}, {
+			none: { hidden: true },
+			one: { hidden: true, primary: b.toString() },
+			several: { hidden: false },
+			singleRoot: undefined,
+		});
+	});
+
+	test('runs the predicate for every root and propagates its rejection (fail open at the caller)', async () => {
+		await assert.rejects(computeFolderPickerDecisionForRoots([a, b], () => Promise.reject(new Error('boom'))));
+	});
+
+	test('passes the token through to the predicate', async () => {
+		const seen: boolean[] = [];
+		await computeFolderPickerDecisionForRoots([a, b], (_dir, token) => { seen.push(token.isCancellationRequested); return Promise.resolve(false); }, CancellationToken.Cancelled);
+		assert.deepStrictEqual(seen, [true, true]);
+	});
+});

--- a/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
+++ b/src/vs/sessions/contrib/providers/remoteAgentHost/test/browser/remoteAgentHostCustomizationHarness.test.ts
@@ -150,6 +150,7 @@ function createTestCustomAgentsService(connection: MockAgentConnection, rootCust
 			}
 			return [...rootCustomizations, ...(sessionState.customizations ?? [])];
 		},
+		getFolderPickerDecision: () => undefined,
 		getWorkingDirectory(sessionResource: URI): string | undefined {
 			return undefined;
 		},

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution.ts
@@ -56,6 +56,9 @@ export class OpenAgentHostFolderPickerAction extends Action2 {
 					IsSessionsWindowContext.negate(),
 					// Equal-peer providers add every workspace folder automatically, so they do not need a primary picker.
 					ChatContextKeys.chatAgentHostHasImmutablePrimaryWorkingDirectory,
+					// Hidden by default; the harness decision reveals the picker (e.g. when several folders carry hooks),
+					// so the chip never flashes visible-then-hidden while the decision is resolving.
+					ChatContextKeys.chatAgentHostFolderPickerVisible,
 				),
 			}],
 		});

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.ts
@@ -16,7 +16,7 @@ import { getCustomizationDisabledReason, isCustomizationEnabled, withCustomizati
 import { type IAgentSubscription } from '../../../../../../platform/agentHost/common/state/agentSubscription.js';
 import { ActionType } from '../../../../../../platform/agentHost/common/state/protocol/actions.js';
 import { CustomizationEnablementKind, CustomizationType, McpServerCustomization, McpServerStatus, type Customization, type CustomizationEnablement, type McpServerState, type PluginCustomization, type RootConfigState, type SessionState } from '../../../../../../platform/agentHost/common/state/protocol/state.js';
-import { AgentCustomization, ROOT_STATE_URI, StateComponents } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { AgentCustomization, ROOT_STATE_URI, StateComponents, readSessionFolderPickerDecision, type ISessionFolderPickerDecision } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
 import { createDecorator, IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IMcpServerConfiguration } from '../../../../../../platform/mcp/common/mcpPlatformTypes.js';
@@ -39,6 +39,14 @@ export interface IAgentHostCustomizationService {
 	getCustomAgents(sessionResource: URI): readonly AgentCustomization[];
 
 	getCustomizations(sessionResource: URI): readonly Customization[];
+
+	/**
+	 * The harness-owned decision about the multi-root Folder picker for a
+	 * session (or `undefined` when the provider expressed no opinion). Read from
+	 * the session's `_meta`; changes are reported via
+	 * {@link onDidChangeCustomizations}.
+	 */
+	getFolderPickerDecision(sessionResource: URI): ISessionFolderPickerDecision | undefined;
 
 	getWorkingDirectory(sessionResource: URI): string | undefined;
 
@@ -98,6 +106,9 @@ export class NullAgentHostCustomizationService implements IAgentHostCustomizatio
 	getCustomizations(_sessionResource: URI): readonly Customization[] {
 		return [];
 	}
+	getFolderPickerDecision(_sessionResource: URI): ISessionFolderPickerDecision | undefined {
+		return undefined;
+	}
 	getWorkingDirectory(sessionResource: URI): string | undefined {
 		return undefined;
 	}
@@ -123,6 +134,7 @@ export class NullAgentHostCustomizationService implements IAgentHostCustomizatio
 
 export interface IAgentHostCustomizationTarget {
 	readonly customizations: readonly Customization[];
+	readonly folderPickerDecision?: ISessionFolderPickerDecision;
 	readonly workingDirectory?: string;
 	readonly workingDirectories?: readonly string[];
 	readonly rootConfig?: RootConfigState;
@@ -167,6 +179,10 @@ export abstract class AbstractAgentHostCustomizationService extends Disposable i
 
 	getCustomizations(sessionResource: URI): readonly Customization[] {
 		return this._resolveTarget(sessionResource)?.customizations ?? [];
+	}
+
+	getFolderPickerDecision(sessionResource: URI): ISessionFolderPickerDecision | undefined {
+		return this._resolveTarget(sessionResource)?.folderPickerDecision;
 	}
 
 	getWorkingDirectory(sessionResource: URI): string | undefined {
@@ -419,6 +435,7 @@ class WorkbenchAgentHostCustomizationService extends AbstractAgentHostCustomizat
 		const channel = target.backendSession.toString();
 		return {
 			customizations: sessionState?.customizations ?? [],
+			folderPickerDecision: readSessionFolderPickerDecision(sessionState?._meta),
 			workingDirectory: sessionState?.workingDirectories?.[0],
 			workingDirectories: sessionState?.workingDirectories,
 			rootConfig: rootState && !(rootState instanceof Error) ? rootState.config : undefined,

--- a/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
+++ b/src/vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.ts
@@ -11,7 +11,7 @@ import { URI } from '../../../../../../base/common/uri.js';
 import { createDecorator } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { InstantiationType, registerSingleton } from '../../../../../../platform/instantiation/common/extensions.js';
 import { IWorkspaceContextService } from '../../../../../../platform/workspace/common/workspace.js';
-import { RootState } from '../../../../../../platform/agentHost/common/state/sessionState.js';
+import { RootState, type ISessionFolderPickerDecision } from '../../../../../../platform/agentHost/common/state/sessionState.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 
 export const IAgentHostNewSessionFolderService = createDecorator<IAgentHostNewSessionFolderService>('agentHostNewSessionFolderService');
@@ -51,6 +51,71 @@ export function supportsMultipleWorkingDirectories(rootState: RootState | Error 
 export function hasImmutablePrimaryWorkingDirectory(rootState: RootState | Error | undefined, provider: string): boolean {
 	const agent = (rootState && !(rootState instanceof Error)) ? rootState.agents.find(a => a.provider === provider) : undefined;
 	return agent?.capabilities?.multipleWorkingDirectories?.immutablePrimary === true;
+}
+
+/**
+ * The change a chat widget should apply to the multi-root Folder picker for the
+ * harness-owned {@link ISessionFolderPickerDecision}. `noop` means retain the
+ * current state (used when a decision transiently disappears during provisional
+ * recreation of the *same* session, so the chip does not flash); `apply` carries
+ * the new visibility value (the picker is hidden by default and only revealed
+ * when the decision says so), the session resource now being tracked, and — only
+ * when the harness pins a primary the user hasn't overridden — the folder to
+ * auto-select.
+ */
+export type FolderPickerDecisionUpdate =
+	| { readonly kind: 'noop' }
+	| { readonly kind: 'apply'; readonly visible: boolean; readonly trackedSessionResource: URI | undefined; readonly selectPrimary: URI | undefined };
+
+/**
+ * Pure resolution of {@link FolderPickerDecisionUpdate} from a widget's current
+ * inputs. Extracted from the widget so the hidden-by-default reveal, tri-state
+ * retain, auto-select gating, after-start suppression, and Agents-window gate are
+ * unit-testable without a live chat widget.
+ *
+ * The picker is hidden until a decision affirmatively reveals it (a decision with
+ * `hidden: false`), so it never flashes visible-then-hidden while the decision is
+ * still resolving.
+ *
+ * @param sessionResource the widget's current session, or `undefined`.
+ * @param agentHostProviderId the locked Agent Host provider, or `undefined` for a non-Agent-Host widget.
+ * @param decision the harness decision for `sessionResource`, or `undefined` when not (yet) known.
+ * @param previousTrackedSessionResource the session the current visibility value reflects.
+ * @param isSessionsWindow whether the widget lives in the Agents window (which owns folder choice).
+ * @param sessionIsEmpty whether the session has no requests yet (its working directory isn't fixed).
+ * @param currentSelectedFolder the folder already chosen for `sessionResource`, if any.
+ */
+export function resolveFolderPickerDecisionUpdate(
+	sessionResource: URI | undefined,
+	agentHostProviderId: string | undefined,
+	decision: ISessionFolderPickerDecision | undefined,
+	previousTrackedSessionResource: URI | undefined,
+	isSessionsWindow: boolean,
+	sessionIsEmpty: boolean,
+	currentSelectedFolder: URI | undefined,
+): FolderPickerDecisionUpdate {
+	if (!sessionResource || !agentHostProviderId) {
+		return { kind: 'apply', visible: false, trackedSessionResource: undefined, selectPrimary: undefined };
+	}
+	const sameSession = previousTrackedSessionResource?.toString() === sessionResource.toString();
+	if (!decision) {
+		// Retain across a provisional recreation of the same session; stay hidden
+		// (the default) for a freshly bound session until a decision reveals it.
+		return sameSession
+			? { kind: 'noop' }
+			: { kind: 'apply', visible: false, trackedSessionResource: sessionResource, selectPrimary: undefined };
+	}
+	let selectPrimary: URI | undefined;
+	// Auto-select the pinned primary only before the session starts (its working
+	// directory is fixed once the first request is sent) and never in the Agents
+	// window, which owns folder choice through its own workspace picker.
+	if (decision.primary && !isSessionsWindow && sessionIsEmpty) {
+		const primary = URI.parse(decision.primary);
+		if (currentSelectedFolder?.toString() !== primary.toString()) {
+			selectPrimary = primary;
+		}
+	}
+	return { kind: 'apply', visible: !decision.hidden, trackedSessionResource: sessionResource, selectPrimary };
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -89,7 +89,8 @@ import { ChatListWidget } from './chatListWidget.js';
 import { ChatFindWidget, IChatFindHost } from './chatFind/chatFindWidget.js';
 import { ChatEditorOptions } from './chatOptions.js';
 import { ChatViewWelcomePart, IChatViewWelcomeContent } from '../viewsWelcome/chatViewWelcomeController.js';
-import { hasImmutablePrimaryWorkingDirectory } from '../agentSessions/agentHost/agentHostNewSessionFolderService.js';
+import { hasImmutablePrimaryWorkingDirectory, resolveFolderPickerDecisionUpdate, IAgentHostNewSessionFolderService } from '../agentSessions/agentHost/agentHostNewSessionFolderService.js';
+import { IAgentHostCustomizationService } from '../agentSessions/agentHost/agentHostCustomizationService.js';
 import { IChatTipService } from '../chatTipService.js';
 import { ChatInputTipPresenter } from './input/chatInputTipPresenter.js';
 import { ChatProgressSubPart } from './chatContentParts/chatProgressContentPart.js';
@@ -409,6 +410,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private readonly _chatIsAgentHostSessionContextKey: IContextKey<boolean>;
 	private readonly _chatAgentHostProviderIdContextKey: IContextKey<string>;
 	private readonly _chatAgentHostHasImmutablePrimaryWorkingDirectoryContextKey: IContextKey<boolean>;
+	private readonly _chatAgentHostFolderPickerVisibleContextKey: IContextKey<boolean>;
+	/** The session resource the {@link _chatAgentHostFolderPickerVisibleContextKey} value currently reflects, so a transient `undefined` decision during provisional recreation retains the value instead of flashing the chip. */
+	private _folderPickerDecisionSessionResource: URI | undefined;
 	private readonly _chatSessionSupportsForkContextKey: IContextKey<boolean>;
 	private readonly _agentSupportsAttachmentsContextKey: IContextKey<boolean>;
 	private readonly _sessionIsEmptyContextKey: IContextKey<boolean>;
@@ -534,6 +538,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		@IChatSubmitRequestHandlerService private readonly chatSubmitRequestHandlerService: IChatSubmitRequestHandlerService,
 		@IChatPetService private readonly chatPetService: IChatPetService,
 		@IAgentHostService private readonly _agentHostService: IAgentHostService,
+		@IAgentHostCustomizationService private readonly _agentHostCustomizationService: IAgentHostCustomizationService,
+		@IAgentHostNewSessionFolderService private readonly _agentHostNewSessionFolderService: IAgentHostNewSessionFolderService,
 	) {
 		super();
 
@@ -549,6 +555,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._chatIsAgentHostSessionContextKey = ChatContextKeys.chatIsAgentHostSession.bindTo(this.contextKeyService);
 		this._chatAgentHostProviderIdContextKey = ChatContextKeys.chatAgentHostProviderId.bindTo(this.contextKeyService);
 		this._chatAgentHostHasImmutablePrimaryWorkingDirectoryContextKey = ChatContextKeys.chatAgentHostHasImmutablePrimaryWorkingDirectory.bindTo(this.contextKeyService);
+		this._chatAgentHostFolderPickerVisibleContextKey = ChatContextKeys.chatAgentHostFolderPickerVisible.bindTo(this.contextKeyService);
 		this._chatSessionSupportsForkContextKey = ChatContextKeys.chatSessionSupportsFork.bindTo(this.contextKeyService);
 		this._agentSupportsAttachmentsContextKey = ChatContextKeys.agentSupportsAttachments.bindTo(this.contextKeyService);
 		this._sessionIsEmptyContextKey = ChatContextKeys.chatSessionIsEmpty.bindTo(this.contextKeyService);
@@ -580,6 +587,14 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		};
 		bindRootState();
 		this._register(this._agentHostService.onAgentHostStart(bindRootState));
+
+		// The harness may hide the Folder picker (and pin a primary) via a
+		// per-session decision in `_meta` — e.g. Copilot auto-selects the sole
+		// workspace folder carrying hooks. Read it from the customization service
+		// (which already subscribes to the session's state) and recompute when it
+		// changes or the widget rebinds to another session.
+		this._register(this._agentHostCustomizationService.onDidChangeCustomizations(() => this._updateFolderPickerDecision()));
+		this._register(this.onDidChangeViewModel(() => this._updateFolderPickerDecision()));
 
 		this.viewContext = viewContext ?? {};
 
@@ -804,6 +819,46 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private _updateAgentHostWorkingDirectoryContextKeys(agentHostProviderId: string | undefined): void {
 		this._chatAgentHostHasImmutablePrimaryWorkingDirectoryContextKey.set(
 			!!agentHostProviderId && hasImmutablePrimaryWorkingDirectory(this._agentHostService.rootState.value, agentHostProviderId));
+	}
+
+	/**
+	 * Applies the harness-owned Folder-picker decision for the current session:
+	 * it sets the visibility context key from the decision and, when the decision
+	 * pins a primary and the session is still empty, auto-selects that folder. The
+	 * decision lives in the session's `_meta` and is surfaced by
+	 * {@link IAgentHostCustomizationService}; the resolution itself lives in the
+	 * pure {@link resolveFolderPickerDecisionUpdate} so it stays testable.
+	 *
+	 * The picker is hidden by default and only revealed once a decision says so,
+	 * so it never flashes visible-then-hidden. A transient `undefined` decision
+	 * for the *same* session is retained rather than reset, so the chip does not
+	 * flicker while a folder change recreates the provisional session.
+	 */
+	private _updateFolderPickerDecision(): void {
+		const sessionResource = this.viewModel?.sessionResource;
+		const agentHostProviderId = this._lockedAgent?.agentHostProviderId;
+		const decision = sessionResource && agentHostProviderId
+			? this._agentHostCustomizationService.getFolderPickerDecision(sessionResource)
+			: undefined;
+		const update = resolveFolderPickerDecisionUpdate(
+			sessionResource,
+			agentHostProviderId,
+			decision,
+			this._folderPickerDecisionSessionResource,
+			!!this.viewOptions.isSessionsWindow,
+			(this.viewModel?.model.getRequests().length ?? 0) === 0,
+			sessionResource ? this._agentHostNewSessionFolderService.getFolder(sessionResource) : undefined,
+		);
+		if (update.kind === 'noop') {
+			return;
+		}
+		this._chatAgentHostFolderPickerVisibleContextKey.set(update.visible);
+		this._folderPickerDecisionSessionResource = update.trackedSessionResource;
+		// `setFolder` deliberately overrides any prior selection, since a hidden
+		// picker leaves the user no way to choose.
+		if (update.selectPrimary && sessionResource) {
+			this._agentHostNewSessionFolderService.setFolder(sessionResource, update.selectPrimary);
+		}
 	}
 
 	get supportsFileReferences(): boolean {
@@ -2686,6 +2741,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._chatIsAgentHostSessionContextKey.set(!!agentHostProviderId);
 		this._chatAgentHostProviderIdContextKey.set(agentHostProviderId ?? '');
 		this._updateAgentHostWorkingDirectoryContextKeys(agentHostProviderId);
+		this._updateFolderPickerDecision();
 		this.renderWelcomeViewContentIfNeeded();
 		// Update capabilities for the locked agent
 		const agent = this.chatAgentService.getAgent(agentId);
@@ -2709,6 +2765,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._chatIsAgentHostSessionContextKey.set(false);
 		this._chatAgentHostProviderIdContextKey.set('');
 		this._chatAgentHostHasImmutablePrimaryWorkingDirectoryContextKey.set(false);
+		this._chatAgentHostFolderPickerVisibleContextKey.set(false);
+		this._folderPickerDecisionSessionResource = undefined;
 		this._chatSessionSupportsForkContextKey.set(false);
 		this._updateAgentCapabilitiesContextKeys(undefined);
 

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -91,6 +91,8 @@ export namespace ChatContextKeys {
 	export const chatAgentHostProviderId = new RawContextKey<string>('chatAgentHostProviderId', '', { type: 'string', description: localize('chatAgentHostProviderId', "The Agent Host provider ID when the chat widget is locked to an Agent Host session.") });
 	/** Widget-scoped: whether the locked Agent Host provider pins an immutable primary working directory. */
 	export const chatAgentHostHasImmutablePrimaryWorkingDirectory = new RawContextKey<boolean>('chatAgentHostHasImmutablePrimaryWorkingDirectory', false, { type: 'boolean', description: localize('chatAgentHostHasImmutablePrimaryWorkingDirectory', "True when the locked Agent Host provider pins an immutable primary working directory.") });
+	/** Widget-scoped: whether the multi-root Folder picker should be shown for this session. Defaults to hidden; the harness decision reveals it, so the chip never flashes visible-then-hidden. */
+	export const chatAgentHostFolderPickerVisible = new RawContextKey<boolean>('chatAgentHostFolderPickerVisible', false, { type: 'boolean', description: localize('chatAgentHostFolderPickerVisible', "True when the multi-root Folder picker should be shown for this Agent Host session (revealed by the harness decision).") });
 	/**
 	 * True when the chat session has a customAgentTarget defined in its contribution,
 	 * which means the mode picker should be shown with filtered custom agents.

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostChatContribution.test.ts
@@ -3538,6 +3538,8 @@ suite('AgentHostChatContribution', () => {
 				[ChatContextKeys.lockedCodingAgentId.key]: 'agent-host-copilot',
 				[ChatContextKeys.chatIsAgentHostSession.key]: true,
 				[ChatContextKeys.chatAgentHostHasImmutablePrimaryWorkingDirectory.key]: true,
+				// Hidden by default; the harness decision reveals the picker.
+				[ChatContextKeys.chatAgentHostFolderPickerVisible.key]: true,
 			};
 
 			assert.deepStrictEqual({
@@ -3546,12 +3548,14 @@ suite('AgentHostChatContribution', () => {
 				sessionsWindow: evalWhen({ ...agentHost, workspaceFolderCount: 2, isSessionsWindow: true }),
 				nonAgentHost: evalWhen({ [ChatContextKeys.lockedCodingAgentId.key]: 'copilot', [ChatContextKeys.chatIsAgentHostSession.key]: false, workspaceFolderCount: 2, isSessionsWindow: false }),
 				noImmutablePrimary: evalWhen({ ...agentHost, [ChatContextKeys.chatAgentHostHasImmutablePrimaryWorkingDirectory.key]: false, workspaceFolderCount: 2, isSessionsWindow: false }),
+				notRevealed: evalWhen({ ...agentHost, [ChatContextKeys.chatAgentHostFolderPickerVisible.key]: false, workspaceFolderCount: 2, isSessionsWindow: false }),
 			}, {
 				multiRootEditor: true,
 				singleFolder: false,
 				sessionsWindow: false,
 				nonAgentHost: false,
 				noImmutablePrimary: false,
+				notRevealed: false,
 			});
 		});
 	});

--- a/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostFolderPickerDecision.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/agentSessions/agentHostFolderPickerDecision.test.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../../base/common/uri.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { FolderPickerDecisionUpdate, resolveFolderPickerDecisionUpdate } from '../../../browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
+
+suite('resolveFolderPickerDecisionUpdate', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const provider = 'copilotcli';
+	const sessionA = URI.parse('agent-host-copilotcli:/a');
+	const sessionB = URI.parse('agent-host-copilotcli:/b');
+	const frontend = URI.file('/ws/frontend');
+	const backend = URI.file('/ws/backend');
+
+	// Normalize URIs to strings so comparisons don't depend on URI internal caches.
+	const norm = (update: FolderPickerDecisionUpdate) => update.kind === 'noop'
+		? { kind: update.kind }
+		: { kind: update.kind, visible: update.visible, tracked: update.trackedSessionResource?.toString(), select: update.selectPrimary?.toString() };
+
+	test('hides the picker for a non-Agent-Host widget or when no session is bound', () => {
+		assert.deepStrictEqual({
+			noSession: norm(resolveFolderPickerDecisionUpdate(undefined, provider, { hidden: false }, sessionA, false, true, undefined)),
+			noProvider: norm(resolveFolderPickerDecisionUpdate(sessionA, undefined, { hidden: false }, sessionA, false, true, undefined)),
+		}, {
+			noSession: { kind: 'apply', visible: false, tracked: undefined, select: undefined },
+			noProvider: { kind: 'apply', visible: false, tracked: undefined, select: undefined },
+		});
+	});
+
+	test('retains the current state on a transient missing decision for the same session, but resets (hidden) for a different one', () => {
+		assert.deepStrictEqual({
+			sameSession: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, undefined, sessionA, false, true, undefined)),
+			differentSession: norm(resolveFolderPickerDecisionUpdate(sessionB, provider, undefined, sessionA, false, true, undefined)),
+			freshWidget: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, undefined, undefined, false, true, undefined)),
+		}, {
+			sameSession: { kind: 'noop' },
+			differentSession: { kind: 'apply', visible: false, tracked: sessionB.toString(), select: undefined },
+			freshWidget: { kind: 'apply', visible: false, tracked: sessionA.toString(), select: undefined },
+		});
+	});
+
+	test('keeps the picker hidden and auto-selects the pinned primary only before the session starts, outside the Agents window', () => {
+		const decision = { hidden: true, primary: backend.toString() };
+		assert.deepStrictEqual({
+			// Empty session, editor window, no prior pick → auto-select the primary.
+			autoSelect: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, decision, sessionA, false, true, undefined)),
+			// Already selected → no redundant re-select.
+			alreadySelected: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, decision, sessionA, false, true, backend)),
+			// Started session (has requests) → suppress auto-select, keep hidden.
+			afterStart: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, decision, sessionA, false, false, undefined)),
+			// Agents window owns folder choice → never auto-select.
+			sessionsWindow: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, decision, sessionA, true, true, undefined)),
+			// A prior (different) user pick is overridden, since a hidden picker leaves no way to choose.
+			overridesPriorPick: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, decision, sessionA, false, true, frontend)),
+		}, {
+			autoSelect: { kind: 'apply', visible: false, tracked: sessionA.toString(), select: backend.toString() },
+			alreadySelected: { kind: 'apply', visible: false, tracked: sessionA.toString(), select: undefined },
+			afterStart: { kind: 'apply', visible: false, tracked: sessionA.toString(), select: undefined },
+			sessionsWindow: { kind: 'apply', visible: false, tracked: sessionA.toString(), select: undefined },
+			overridesPriorPick: { kind: 'apply', visible: false, tracked: sessionA.toString(), select: backend.toString() },
+		});
+	});
+
+	test('reveals the picker without selecting anything when the harness does not pin a primary', () => {
+		assert.deepStrictEqual({
+			shownNoPrimary: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, { hidden: false }, sessionA, false, true, undefined)),
+			hiddenNoPrimary: norm(resolveFolderPickerDecisionUpdate(sessionA, provider, { hidden: true }, sessionA, false, true, frontend)),
+		}, {
+			shownNoPrimary: { kind: 'apply', visible: true, tracked: sessionA.toString(), select: undefined },
+			hiddenNoPrimary: { kind: 'apply', visible: false, tracked: sessionA.toString(), select: undefined },
+		});
+	});
+});

--- a/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/chat/chatFixtureUtils.ts
@@ -43,6 +43,7 @@ import { IAgentSessionsService } from '../../../../contrib/chat/browser/agentSes
 import { IAgentHostUntitledProvisionalSessionService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostNewSessionFolderService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
+import { IAgentHostCustomizationService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.js';
 import { IVoiceModeOnboardingService } from '../../../../contrib/agentsVoice/browser/voiceModeOnboarding.js';
 import { IChatAccessibilityService, IChatWidget, IChatWidgetService } from '../../../../contrib/chat/browser/chat.js';
 import { IChatResponseFileChangesService } from '../../../../contrib/chat/browser/chatResponseFileChangesService.js';
@@ -334,6 +335,10 @@ export function registerChatFixtureServices(reg: ServiceRegistration, options: I
 	reg.defineInstance(IAgentHostNewSessionFolderService, new class extends mock<IAgentHostNewSessionFolderService>() {
 		override readonly onDidChangeFolder = Event.None;
 		override getFolder() { return undefined; }
+	}());
+	reg.defineInstance(IAgentHostCustomizationService, new class extends mock<IAgentHostCustomizationService>() {
+		override readonly onDidChangeCustomizations = Event.None;
+		override getFolderPickerDecision() { return undefined; }
 	}());
 	reg.defineInstance(IAgentHostEnablementService, new class extends mock<IAgentHostEnablementService>() {
 		override readonly enabled = constObservable(false);

--- a/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
+++ b/src/vs/workbench/test/browser/componentFixtures/editor/inlineChatZoneWidget.fixture.ts
@@ -59,6 +59,7 @@ import { RootState } from '../../../../../platform/agentHost/common/state/sessio
 import { IAgentHostUntitledProvisionalSessionService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostUntitledProvisionalSessionService.js';
 import { IAgentHostSessionWorkingDirectoryResolver } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectoryResolver.js';
 import { IAgentHostNewSessionFolderService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostNewSessionFolderService.js';
+import { IAgentHostCustomizationService } from '../../../../contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService.js';
 import { IWorkspaceContextService, IWorkspace } from '../../../../../platform/workspace/common/workspace.js';
 import { IViewDescriptorService } from '../../../../common/views.js';
 import { IListService, ListService } from '../../../../../platform/list/browser/listService.js';
@@ -296,6 +297,10 @@ function renderInlineChatZoneWidget({ container, disposableStore, theme }: Compo
 			reg.defineInstance(IAgentHostNewSessionFolderService, new class extends mock<IAgentHostNewSessionFolderService>() {
 				override readonly onDidChangeFolder = Event.None;
 				override getFolder() { return undefined; }
+			}());
+			reg.defineInstance(IAgentHostCustomizationService, new class extends mock<IAgentHostCustomizationService>() {
+				override readonly onDidChangeCustomizations = Event.None;
+				override getFolderPickerDecision() { return undefined; }
 			}());
 			reg.defineInstance(IChatContextService, new class extends mock<IChatContextService>() { }());
 			reg.defineInstance(IChatAttachmentWidgetRegistry, new class extends mock<IChatAttachmentWidgetRegistry>() { }());


### PR DESCRIPTION
## How the Folder picker is shown/hidden in this PR

**Default: hidden.** The picker chip is gated on a widget context key `chatAgentHostFolderPickerVisible` that defaults to `false`, so it stays hidden unless something explicitly reveals it. This avoids the chip flashing visible-then-hidden while the (async) decision is still resolving.

**The harness decides.** When a new **multi-root** agent-host session is created, the provider (Copilot/Claude/Codex) computes a decision and we store it in the session's `_meta` under `vscode.folderPicker`:

```ts
{ hidden: boolean, primary?: string }   // primary = URI to auto-select
```

The decision comes from counting how many workspace folders "qualify" (carry provider config that must lead — Copilot `.github/hooks/`, Claude `.mcp.json`/hooks, Codex `.codex/hooks.json`):

| Qualifying folders | `_meta` value | Picker |
|---|---|---|
| 0 | `{ hidden: true }` | **Hidden** (any folder is fine, keep current selection) |
| exactly 1 | `{ hidden: true, primary }` | **Hidden**, and that folder is auto-selected as primary |
| 2 or more | `{ hidden: false }` | **Shown** — user picks which folder leads |
| single-folder / fork / import | no decision written | **Hidden** (picker doesn't apply) |

**The client obeys `_meta`.** `ChatWidget` reads the decision, runs the pure `resolveFolderPickerDecisionUpdate(...)`, and sets `chatAgentHostFolderPickerVisible = !decision.hidden`. If a `primary` is pinned and the session is still empty, it auto-selects that folder. A missing decision keeps the hidden default (and is *retained* — not reset — during provisional session recreation, so the chip never flickers).

**It's frozen at creation.** The decision is persisted to the session DB and restored on reload, so a session created with the picker hidden stays hidden, and one created with it shown stays shown.

**One line:** show/hide is driven entirely by a harness-written `{ hidden }` flag in session `_meta`; the picker defaults to hidden and is only shown when the harness sets `hidden: false` (≥2 folders qualify), auto-pinning the folder when exactly one qualifies.

## Tests

Unit tests cover the shared decision (`folderPickerDecision.test.ts`), each provider's criteria (Copilot/Claude/Codex), the `_meta` round-trip (`sessionFolderPickerMeta.test.ts`), and the client-side resolver (`agentHostFolderPickerDecision.test.ts`).

## Review note

Draft, opened for review. Automated review flagged one point to resolve before ready: the Copilot hook-scan is documented/tested to *fail open* on IO errors, but `AgentService.createSession` currently collapses the rejection to `undefined`, which the client treats as hidden (fail-closed). Worth aligning so a transient IO error shows the picker rather than silently pinning folder index 0.
