### PR TITLE
agentHost: stabilize session config integration tests

### DIFF
--- a/src/vs/platform/agentHost/test/node/protocol/sessionConfig.integrationTest.ts
+++ b/src/vs/platform/agentHost/test/node/protocol/sessionConfig.integrationTest.ts
@@ -107,6 +107,7 @@ suite('Protocol WebSocket - Session Config', function () {
 
 		const notif = await client.waitForNotification(n =>
 			n.method === 'root/sessionAdded'
+			&& (n.params as SessionAddedParams).summary.resource !== PRE_EXISTING_SESSION_URI.toString()
 		);
 		const notification = notif.params as SessionAddedParams;
 		assert.strictEqual(Object.hasOwn(notification.summary, 'config'), false);
@@ -128,6 +129,7 @@ suite('Protocol WebSocket - Session Config', function () {
 
 		const notif = await client.waitForNotification(n =>
 			n.method === 'root/sessionAdded'
+			&& (n.params as SessionAddedParams).summary.resource !== PRE_EXISTING_SESSION_URI.toString()
 		);
 		const session = (notif.params as SessionAddedParams).summary.resource;
 		await client.call<SubscribeResult>('subscribe', { channel: session });


### PR DESCRIPTION
## Summary

- ignore the mock provider's asynchronously discovered pre-existing session in session-config notification waits
- prevent the tests from subscribing to an unrelated session with no config

## Root cause

Windows Electron integration tests in [build 464537](https://dev.azure.com/monacotools/a6d41577-0fa3-498e-af22-257312ff0545/_build/results?buildId=464537) occasionally consumed the `root/sessionAdded` notification for `PRE_EXISTING_SESSION_URI` instead of the session created by the test. Provider-native chat discovery made the ordering nondeterministic.

## Validation

- `npm run transpile-client`
- `node --experimental-strip-types build/hygiene.ts src/vs/platform/agentHost/test/node/protocol/sessionConfig.integrationTest.ts`
- targeted affected tests passed once, then passed 10 consecutive stress runs

(Written by Copilot)