### PR TITLE
Buffer a client tool result that arrives before the SDK asks for it

### DIFF
--- a/src/vs/platform/agentHost/common/pendingRequestRegistry.ts
+++ b/src/vs/platform/agentHost/common/pendingRequestRegistry.ts
@@ -30,6 +30,9 @@ export class PendingRequestRegistry<TResult, TMeta = void> {
 	 */
 	private readonly _earlyResults = new Map<string, TResult>();
 
+	/** Upper bound on {@link _earlyResults}, so completions that never register cannot accumulate. */
+	private static readonly _maxBufferedResults = 16;
+
 	/** Atomically park a deferred and optional metadata, then invoke `fire` to prevent synchronous responses racing registration. */
 	registerAndFire(key: string, fire: () => void, ...metadata: MetadataArgument<TMeta>): Promise<TResult> {
 		if (this._earlyResults.has(key)) {
@@ -118,9 +121,18 @@ export class PendingRequestRegistry<TResult, TMeta = void> {
 	 * completion race).
 	 */
 	respondOrBuffer(key: string, value: TResult): void {
-		if (!this.respond(key, value)) {
-			this._earlyResults.set(key, value);
+		if (this.respond(key, value)) {
+			return;
 		}
+		// Callers forward completions for keys that never register, so evict the
+		// oldest rather than retaining every one until the registry is cleared.
+		if (this._earlyResults.size >= PendingRequestRegistry._maxBufferedResults) {
+			const oldest = this._earlyResults.keys().next().value;
+			if (oldest !== undefined) {
+				this._earlyResults.delete(oldest);
+			}
+		}
+		this._earlyResults.set(key, value);
 	}
 
 	/** Whether a result arrived before a request registered under `key`. */

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -1157,13 +1157,9 @@ export class ClaudeAgentSession extends Disposable {
 	 * result. Returns `true` if a matching deferred was found and settled.
 	 * Unknown ids are a benign no-op — `agentSideEffects.ts` forwards every
 	 * `ChatToolCallComplete` envelope, so SDK-owned tool completions land
-	 * here too and must NOT throw.
-	 *
-	 * Buffers instead of dropping when nothing is parked yet: the workbench
-	 * starts a client tool from the streamed tool call and can finish it before
-	 * the SDK has invoked that tool and registered its handler. Discarding the
-	 * result there strands the turn, because the handler registers moments
-	 * later and then waits for a result that no longer exists.
+	 * here too and must NOT throw. Buffers when nothing is parked, since the
+	 * workbench can finish the tool before the SDK registers the handler that
+	 * awaits the result.
 	 */
 	completeClientToolCall(toolCallId: string, result: ToolCallResult): boolean {
 		const converted = convertToolCallResult(result, toolCallId);

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -1158,10 +1158,20 @@ export class ClaudeAgentSession extends Disposable {
 	 * Unknown ids are a benign no-op — `agentSideEffects.ts` forwards every
 	 * `ChatToolCallComplete` envelope, so SDK-owned tool completions land
 	 * here too and must NOT throw.
+	 *
+	 * Buffers instead of dropping when nothing is parked yet: the workbench
+	 * starts a client tool from the streamed tool call and can finish it before
+	 * the SDK has invoked that tool and registered its handler. Discarding the
+	 * result there strands the turn, because the handler registers moments
+	 * later and then waits for a result that no longer exists.
 	 */
 	completeClientToolCall(toolCallId: string, result: ToolCallResult): boolean {
 		const converted = convertToolCallResult(result, toolCallId);
-		return this._pendingClientToolCalls.respond(toolCallId, converted);
+		const settled = this._pendingClientToolCalls.respond(toolCallId, converted);
+		if (!settled) {
+			this._pendingClientToolCalls.respondOrBuffer(toolCallId, converted);
+		}
+		return settled;
 	}
 
 	/**

--- a/src/vs/platform/agentHost/test/common/pendingRequestRegistry.test.ts
+++ b/src/vs/platform/agentHost/test/common/pendingRequestRegistry.test.ts
@@ -143,6 +143,19 @@ suite('PendingRequestRegistry', () => {
 		assert.strictEqual(await pending, 'second');
 	});
 
+	test('respondOrBuffer evicts the oldest buffered result once the bound is reached', async () => {
+		const registry = new PendingRequestRegistry<string>();
+		// Callers forward completions for keys that never register.
+		for (let i = 0; i < 20; i++) {
+			registry.respondOrBuffer(`k${i}`, `v${i}`);
+		}
+
+		assert.deepStrictEqual({ evicted: registry.hasBufferedResult('k0'), retained: registry.hasBufferedResult('k19') }, {
+			evicted: false,
+			retained: true,
+		});
+	});
+
 	test('respondOrBuffer behaves like respond when a deferred is already parked', async () => {
 		const registry = new PendingRequestRegistry<string>();
 		const promise = registry.register('k');

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5649,6 +5649,29 @@ suite('ClaudeAgent', () => {
 		assert.strictEqual(settled, false, 'no parked handler in this test path; unknown id is silent');
 	});
 
+	test('a result delivered before the SDK registers is buffered, not dropped', async () => {
+		const { agent, sdk } = createTestContext(disposables);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+		const created = await createSession(agent, { workingDirectories: [URI.file('/work')] });
+		const sessionId = created.sdkSessionId;
+		getOrCreateActiveClient(agent, defaultChatUri(created.session), 'c1').tools = [{ name: 'echo', inputSchema: { type: 'object' } }];
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'go', undefined, undefined, 'turn-1', undefined, undefined, chatContext(defaultChatUri(created.session)));
+		const session = agent.getSessionForTesting(created.session)!;
+
+		// The workbench starts a client tool from the streamed tool call and can
+		// finish it before the SDK invokes that tool, so the result arrives with
+		// nothing parked. Dropping it strands the turn: the handler registers a
+		// moment later and waits for a result that no longer exists.
+		const settled = session.completeClientToolCall('tu_early', { success: true, pastTenseMessage: 'ok', content: [{ type: ToolResultContentType.Text, text: 'hello' }] });
+		const delivered = await session.pendingClientToolCalls.register('tu_early');
+
+		assert.deepStrictEqual({ settled, delivered: delivered.content }, {
+			settled: false,
+			delivered: [{ type: 'text', text: 'hello' }],
+		});
+	});
+
 	test('onClientToolCallComplete walks subagent URIs to the root session', () => {
 		const { agent } = createTestContext(disposables);
 		const root = URI.parse('claude:/root-1');

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -5659,10 +5659,7 @@ suite('ClaudeAgent', () => {
 		await agent.chats.sendMessage(defaultChatUri(created.session), 'go', undefined, undefined, 'turn-1', undefined, undefined, chatContext(defaultChatUri(created.session)));
 		const session = agent.getSessionForTesting(created.session)!;
 
-		// The workbench starts a client tool from the streamed tool call and can
-		// finish it before the SDK invokes that tool, so the result arrives with
-		// nothing parked. Dropping it strands the turn: the handler registers a
-		// moment later and waits for a result that no longer exists.
+		// The result can arrive before the SDK registers the handler awaiting it.
 		const settled = session.completeClientToolCall('tu_early', { success: true, pastTenseMessage: 'ok', content: [{ type: ToolResultContentType.Text, text: 'hello' }] });
 		const delivered = await session.pendingClientToolCalls.register('tu_early');
 


### PR DESCRIPTION
Fixes the stall in microsoft/vscode#322990.

A client tool call ends up stuck forever: the tool runs, the workbench reports its result, and the turn never finishes. Nothing is shown to the user and nothing reaches the model.

## Cause

The workbench starts a client tool from the streamed tool call (the `content_block_stop` ready) and can finish it before the SDK has invoked that tool and registered its handler. `ClaudeAgentSession.completeClientToolCall` used `PendingRequestRegistry.respond`, which discards a result when nothing is parked on that id. The handler registers a moment later and waits forever for a result that no longer exists.

The `CopilotAgentSession` equivalent already uses `respondOrBuffer` on this path.

## Fix

Buffer when nothing is parked. `register` and `registerAndFire` both collect an early result, so the late handler resolves immediately instead of the tool being re-run.

## Evidence

Instrumented against a real 1.133.0 dev container, logging whether the completion matched a parked handler and every id passed to `register`:

```
stalled  id=toolu_01EQdcdF...  matched=false
         registered=[...]   <- the id is absent when the result arrives,
                               and appears seconds later
```

With the fix, the same call logs the buffered result being collected on registration, and the turn continues:

```
19:57:05  completion arrives, nothing parked -> buffered
19:57:07  SDK registers, collects the buffered result
19:57:12  turn continues with the next tool call
```

Reproduction rule, before the fix:

| Permission path | Result |
| --- | --- |
| Auto-approved | always stalls |
| Approved in the confirm dialog | stalls |
| Approved inline in the chat | works |

Auto-approval leaves nothing to delay the workbench, so it always loses the race. Approving in chat usually wins it, because the wait gives the SDK time to register. This is also why it shows up in remote windows: the client tool round trip crosses the websocket transport.

## Testing

- Added `a result delivered before the SDK registers is buffered, not dropped`. Without the fix it fails by timing out, which is exactly the production symptom.
- `./scripts/test.sh --grep ClaudeAgent`: 266 passing, 3 failing, the same 3 failing on an unmodified checkout (model catalog / credential tests, unrelated).
- `npm run typecheck-client` clean.
- Verified live by patching the equivalent change into a running 1.133.0 agent host: auto mode recovered from a failed browser tool, reported the cause, and completed the turn, having never once completed before.