### PR TITLE
agentHost: configure external session exposure

### DIFF
--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -468,6 +468,15 @@ export const AgentHostActiveAgentTitleGenerationConfigKey = 'activeAgentTitleGen
 // sessions as adoptable agent-host sessions, and opening one adopts it in place. Experimental; off.
 export const AgentHostMigrateLegacyCopilotCliEnabledConfigKey = 'migrateLegacyCopilotCliEnabled';
 
+export const AgentHostShowExternalSessionsConfigKey = 'showExternalSessions';
+
+export const enum AgentHostExternalSessionsMode {
+	None = 'none',
+	All = 'all',
+	Last24Hours = 'last24Hours',
+	Last7Days = 'last7Days',
+}
+
 /**
  * Root config key forwarded from the renderer that gates multiple-working-directory
  * support for the Copilot provider. When `true`, the Copilot provider advertises
@@ -753,6 +762,13 @@ export const platformRootSchema = createSchema({
 		title: localize('agentHost.config.migrateLegacyCopilotCliEnabled.title', "Migrate Legacy Copilot CLI Sessions"),
 		description: localize('agentHost.config.migrateLegacyCopilotCliEnabled.description', "Whether un-adopted extension-host Copilot CLI sessions are surfaced as adoptable agent-host sessions and migrated in place when opened."),
 		default: false,
+	}),
+	[AgentHostShowExternalSessionsConfigKey]: schemaProperty<AgentHostExternalSessionsMode>({
+		type: 'string',
+		title: localize('agentHost.config.showExternalSessions.title', "Show External Agent Sessions"),
+		description: localize('agentHost.config.showExternalSessions.description', "Controls whether sessions created by supported external agent applications are included in the session catalog."),
+		enum: [AgentHostExternalSessionsMode.None, AgentHostExternalSessionsMode.All, AgentHostExternalSessionsMode.Last24Hours, AgentHostExternalSessionsMode.Last7Days],
+		default: AgentHostExternalSessionsMode.Last7Days,
 	}),
 	[AgentHostCopilotMultiRootEnabledConfigKey]: schemaProperty<boolean>({
 		type: 'boolean',

--- a/src/vs/platform/agentHost/common/state/sessionState.ts
+++ b/src/vs/platform/agentHost/common/state/sessionState.ts
@@ -1189,7 +1189,7 @@ export const SESSION_META_PROMPT_CACHE_KEY = 'vscode.promptCache';
 
 export const SESSION_META_MULTI_ROOT_KEY = 'multiRoot';
 
-/** Reserved key for whether a session was first discovered in a provider-native catalog. */
+/** Reserved key for a session that remains provider-native and has not been used through Agent Host. */
 export const SESSION_META_EXTERNAL_KEY = 'vscode.external';
 
 const MAX_WORKSPACE_FILE_LENGTH = 4096;
@@ -1711,7 +1711,7 @@ export function withSessionWorkspaceless(meta: SessionSummaryMeta | undefined, w
 	return Object.keys(next).length > 0 ? next : undefined;
 }
 
-/** Whether the session was first discovered in a provider-native catalog. */
+/** Whether the session remains provider-native and has not been used through Agent Host. */
 export function readSessionExternal(meta: SessionSummaryMeta | undefined): boolean {
 	return meta?.[SESSION_META_EXTERNAL_KEY] === true;
 }

--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -793,6 +793,21 @@ export class AgentHostStateManager extends Disposable {
 		});
 	}
 
+	/** Unconditionally re-announces a restored live session that newly became visible. The caller owns notification deduplication. */
+	announceLiveSession(session: string): void {
+		const summary = this.getSessionSummary(session);
+		if (!summary) {
+			this._logService.warn(`[AgentHostStateManager] announceLiveSession: unknown session ${session}`);
+			return;
+		}
+		this._summaryNotifier.announce(session, summary);
+		this._onDidEmitNotification.fire({
+			type: 'root/sessionAdded',
+			channel: ROOT_STATE_URI,
+			summary,
+		});
+	}
+
 	/** Retracts a surfaced session without disturbing a restored live session. */
 	retractSurfacedSession(session: string): void {
 		if (this._sessionStates.has(session)) {

--- a/src/vs/platform/agentHost/node/agentHostStateManager.ts
+++ b/src/vs/platform/agentHost/node/agentHostStateManager.ts
@@ -793,6 +793,19 @@ export class AgentHostStateManager extends Disposable {
 		});
 	}
 
+	/** Retracts a surfaced session without disturbing a restored live session. */
+	retractSurfacedSession(session: string): void {
+		if (this._sessionStates.has(session)) {
+			return;
+		}
+		this._summaryNotifier.remove(session);
+		this._onDidEmitNotification.fire({
+			type: 'root/sessionRemoved',
+			channel: ROOT_STATE_URI,
+			session,
+		});
+	}
+
 	/**
 	 * Restores a session from a previous server lifetime into the state manager
 	 * with pre-populated turns. The session is created in `ready` lifecycle

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -36,7 +36,7 @@ import type { InvokeChangesetOperationParams, InvokeChangesetOperationResult } f
 import { AhpErrorCodes, AHP_SESSION_NOT_FOUND, ContentEncoding, JSON_RPC_INTERNAL_ERROR, ProtocolError, ResourceChangeType, ResourceType, ResourceWriteMode, type CreateResourceWatchParams, type CreateResourceWatchResult, type DirectoryEntry, type ResourceCopyParams, type ResourceCopyResult, type ResourceDeleteParams, type ResourceDeleteResult, type ResourceListResult, type ResourceMkdirParams, type ResourceMkdirResult, type ResourceMoveParams, type ResourceMoveResult, type ResourceReadResult, type ResourceResolveParams, type ResourceResolveResult, type ResourceWatchState, type ResourceWriteParams, type ResourceWriteResult, type IStateSnapshot } from '../common/state/sessionProtocol.js';
 import { ChangesSummary, ChatInteractivity, ChatOriginKind, MessageAttachmentKind, type ChatOrigin, type Customization, type Message, type MessageAttachment, type MessageResourceAttachment } from '../common/state/protocol/state.js';
 import type { ChatPendingMessageSetAction, ChatTurnStartedAction } from '../common/state/protocol/actions.js';
-import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SESSION_META_MULTI_ROOT_KEY, SESSION_META_SOURCE_CONTROL_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionLifecycle, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, AH_META_IS_READ_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isDefaultChatUri, isSubagentChatUri, isSubagentSession, parseChatUri, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSessionMultiRootMetadata, parseSubagentSessionUri, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionSourceControlState, readSessionWorkspaceless, withSessionExternal, withSessionGitHubState, withSessionGitState, withSessionMultiRootMetadata, withSessionSourceControlState, withSessionStatusFlag, withSessionWorkspaceless, readSessionEhcliAdoptable, type ISessionSourceControlState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn, type UsageInfo, chatStorageUri, hasReportedUsage } from '../common/state/sessionState.js';
+import { ISessionGitHubState, ISessionGitState, MessageKind, ResponsePartKind, SESSION_META_GITHUB_KEY, SESSION_META_GIT_KEY, SESSION_META_MULTI_ROOT_KEY, SESSION_META_SOURCE_CONTROL_KEY, readSessionSpawnDepth, withSessionSpawnDepth, SessionLifecycle, SessionStatus, ToolCallStatus, ToolResultContentType, AH_META_WORKSPACELESS_DB_KEY, AH_META_IS_ARCHIVED_DB_KEY, AH_META_IS_DONE_DB_KEY, AH_META_IS_READ_DB_KEY, buildChatUri, buildDefaultChatUri, buildResourceWatchChannelUri, buildSubagentChatUri, buildSubagentSessionUriPrefix, hostBuildInfoFromProduct, isAhpChatChannel, isDefaultChatUri, isSubagentChatUri, isSubagentSession, parseChatUri, parseDefaultChatUri, parseRequiredSessionUriFromChatUri, parseResourceWatchChannelUri, parseSessionMultiRootMetadata, parseSubagentSessionUri, readSessionExternal, readSessionGitHubState, readSessionGitState, readSessionMultiRootMetadata, readSessionSourceControlState, readSessionWorkspaceless, withSessionExternal, withSessionGitHubState, withSessionGitState, withSessionMultiRootMetadata, withSessionSourceControlState, withSessionStatusFlag, withSessionWorkspaceless, readSessionEhcliAdoptable, type ISessionSourceControlState, type SessionConfigState, type SessionSummary, type ToolResultSubagentContent, type Turn, type UsageInfo, chatStorageUri, hasReportedUsage } from '../common/state/sessionState.js';
 import { readToolCallMeta } from '../common/meta/agentToolCallMeta.js';
 import { IProductService } from '../../product/common/productService.js';
 import { buildBoundedSideChatSourceContext, getSideChatPartialResponse } from './agentPeerChats.js';
@@ -88,7 +88,7 @@ import { ITelemetryService } from '../../telemetry/common/telemetry.js';
 import { NullTelemetryService } from '../../telemetry/common/telemetryUtils.js';
 import { AgentHostAuthenticationService } from './agentHostAuthenticationService.js';
 import { updateAgentHostTelemetryLevelFromConfig } from './agentHostTelemetryService.js';
-import { AgentHostActiveAgentTitleGenerationConfigKey, AgentHostEditTelemetryEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, platformRootSchema } from '../common/agentHostSchema.js';
+import { AgentHostActiveAgentTitleGenerationConfigKey, AgentHostEditTelemetryEnabledConfigKey, AgentHostExternalSessionsMode, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostShowExternalSessionsConfigKey, platformRootSchema } from '../common/agentHostSchema.js';
 import { AgentHostCustomizationEnablementService, IAgentHostCustomizationEnablementService } from './agentHostCustomizationEnablementService.js';
 import { AgentHostStorageService, IAgentHostStorageService } from './agentHostStorageService.js';
 import { AgentHostOctoKitService, IAgentHostOctoKitService } from './shared/agentHostOctoKitService.js';
@@ -307,6 +307,15 @@ export class AgentService extends Disposable implements IAgentService {
 	 * deleted session is harmless — that URI is never reachable again.
 	 */
 	private readonly _unpersistedChatBackings = new Set<string>();
+	private readonly _sessionsUsedByAgentHost = new Set<string>();
+	private readonly _sessionUsePersistence = new Map<string, Promise<void>>();
+	private readonly _discoveredSessionMetadata = new Map<string, IAgentSessionMetadata>();
+	private readonly _broadcastExternalSessions = new Set<string>();
+	private readonly _broadcastExternalSessionMetadata = new Map<string, IAgentSessionMetadata>();
+	private readonly _externalSessionExpiry = this._register(new MutableDisposable());
+	private _externalSessionExpiryAt: number | undefined;
+	private _externalSessionReconciliation = Promise.resolve();
+	private _externalSessionsMode = AgentHostExternalSessionsMode.Last7Days;
 
 	/** Exposes the state manager for co-hosting a WebSocket protocol server. */
 	get stateManager(): AgentHostStateManager { return this._stateManager; }
@@ -499,6 +508,7 @@ export class AgentService extends Disposable implements IAgentService {
 		private readonly _hostLaunchKind = AgentHostLaunchKind.Unknown,
 		storageResource?: URI,
 		orchestratorDatabase?: IAgentHostDatabase,
+		private readonly _now: () => number = Date.now,
 	) {
 		super();
 		this._logService.info('AgentService initialized');
@@ -526,6 +536,15 @@ export class AgentService extends Disposable implements IAgentService {
 		// via DI rather than being plumbed plain-class references.
 		const configurationService = this._register(new AgentConfigurationService(this._stateManager, this._logService, this._rootConfigResource, providerConfigurations));
 		this._configurationService = configurationService;
+		this._externalSessionsMode = this._getExternalSessionsMode();
+		this._register(configurationService.onDidRootConfigChange(() => {
+			const previousMode = this._externalSessionsMode;
+			const mode = this._getExternalSessionsMode();
+			if (mode !== previousMode) {
+				this._externalSessionsMode = mode;
+				this._queueExternalSessionReconciliation(previousMode);
+			}
+		}));
 		const fileMonitorService = _fileMonitorService ?? this._register(new AgentHostFileMonitorService(this._fileService, this._logService));
 		this._storageService = this._register(new AgentHostStorageService(storageResource, this._logService));
 		updateAgentHostTelemetryLevelFromConfig(this._telemetryService, this._stateManager.rootState.config?.values);
@@ -1225,6 +1244,7 @@ export class AgentService extends Disposable implements IAgentService {
 			};
 		})));
 		let changed = false;
+		const surfaced: { readonly identity: IRegisteredSession; readonly metadata: IAgentSessionMetadata }[] = [];
 		for (const discovered of identities) {
 			if (!discovered) {
 				continue;
@@ -1232,9 +1252,23 @@ export class AgentService extends Disposable implements IAgentService {
 			const { identity, metadata } = discovered;
 			const registered = await this._sessionRegistry.register(identity.session, identity, { checkTombstone: true });
 			if (registered) {
-				await this._announceSurfacedSession(metadata, provider.id);
+				surfaced.push({ identity, metadata });
 			}
 			changed = registered || changed;
+		}
+		if (surfaced.length > 0) {
+			const authoritative = new Map((await this._listRegisteredSessions()).map(entry => [entry.session.toString(), entry]));
+			for (const { identity, metadata } of surfaced) {
+				const external = authoritative.get(identity.session.toString())?.external ?? identity.external;
+				const surfacedMetadata = { ...metadata, _meta: withSessionExternal(metadata._meta, external) };
+				this._discoveredSessionMetadata.set(identity.session.toString(), surfacedMetadata);
+				if (!external || readSessionEhcliAdoptable(metadata._meta)) {
+					await this._announceSurfacedSession(surfacedMetadata, provider.id);
+				}
+			}
+		}
+		if (changed) {
+			this._queueExternalSessionReconciliation();
 		}
 		return changed;
 	}
@@ -1261,6 +1295,8 @@ export class AgentService extends Disposable implements IAgentService {
 			const external = await this._isExternalProviderChat(s.session);
 			return { session: s.session, provider: provider.id, startTime: s.startTime, external, source: external ? 'discovery' : 'restore' };
 		})));
+		let changed = false;
+		const surfaced: { readonly identity: IRegisteredSession; readonly metadata: IAgentSessionMetadata }[] = [];
 		for (let index = 0; index < identities.length; index++) {
 			const identity = identities[index];
 			if (!identity) {
@@ -1268,11 +1304,25 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 			const registered = await this._sessionRegistry.register(identity.session, identity, { checkTombstone: true });
 			if (registered) {
-				const metadata = sessions[index];
-				await this._announceSurfacedSession({ ...metadata, _meta: withSessionExternal(metadata._meta, identity.external) }, provider.id);
+				surfaced.push({ identity, metadata: sessions[index] });
+			}
+			changed = registered || changed;
+		}
+		if (surfaced.length > 0) {
+			const authoritative = new Map((await this._listRegisteredSessions()).map(entry => [entry.session.toString(), entry]));
+			for (const { identity, metadata } of surfaced) {
+				const external = authoritative.get(identity.session.toString())?.external ?? identity.external;
+				const surfacedMetadata = { ...metadata, _meta: withSessionExternal(metadata._meta, external) };
+				this._discoveredSessionMetadata.set(identity.session.toString(), surfacedMetadata);
+				if (!external || readSessionEhcliAdoptable(metadata._meta)) {
+					await this._announceSurfacedSession(surfacedMetadata, provider.id);
+				}
 			}
 		}
 		await this._sessionRegistry.markProviderBackfilled(provider.id);
+		if (changed) {
+			this._queueExternalSessionReconciliation();
+		}
 	}
 
 	private async _isExternalProviderChat(session: URI): Promise<boolean> {
@@ -1336,7 +1386,7 @@ export class AgentService extends Disposable implements IAgentService {
 			return false;
 		}
 	}
-	async listSessions(): Promise<IAgentSessionMetadata[]> {
+	async listSessions(mode = this._externalSessionsMode, preferLiveState = false, preferDiscoveredMetadata = false): Promise<IAgentSessionMetadata[]> {
 		this._logService.trace('[AgentService] listSessions called');
 		// The first list waits for registration-time discovery if it is still in flight.
 		await this._awaitInitialProviderDiscovery();
@@ -1352,6 +1402,15 @@ export class AgentService extends Disposable implements IAgentService {
 			// them then.
 			if (this._stateManager.isIdleProvisionalSession(session.toString())) {
 				return undefined;
+			}
+			if (preferLiveState && this._stateManager.getSessionState(session.toString())) {
+				return undefined;
+			}
+			if (preferDiscoveredMetadata) {
+				const discovered = this._discoveredSessionMetadata.get(session.toString());
+				if (discovered) {
+					return { ...discovered, _meta: withSessionExternal(discovered._meta, external) };
+				}
 			}
 
 			const agent = this._providers.get(provider);
@@ -1557,9 +1616,163 @@ export class AgentService extends Disposable implements IAgentService {
 			});
 		}
 		const combined = additions.length > 0 ? [...withStatus, ...additions] : withStatus;
+		const visible = combined
+			.map(session => this._forceUnusedExternalSessionRead(session))
+			.filter(session => this._shouldIncludeSession(session, mode));
 
-		this._logService.trace(`[AgentService] listSessions returned ${combined.length} sessions (${additions.length} state-manager fallback)`);
-		return combined;
+		this._logService.trace(`[AgentService] listSessions returned ${visible.length} sessions (${additions.length} state-manager fallback)`);
+		return visible;
+	}
+
+	private _forceUnusedExternalSessionRead(session: IAgentSessionMetadata): IAgentSessionMetadata {
+		if (!readSessionExternal(session._meta) || this._sessionsUsedByAgentHost.has(session.session.toString())) {
+			return session;
+		}
+		return {
+			...session,
+			status: withSessionStatusFlag(session.status ?? SessionStatus.Idle, SessionStatus.IsRead, true),
+		};
+	}
+
+	private _getExternalSessionsMode(): AgentHostExternalSessionsMode {
+		return this._configurationService.getRootValue(platformRootSchema, AgentHostShowExternalSessionsConfigKey) ?? AgentHostExternalSessionsMode.Last7Days;
+	}
+
+	private _shouldIncludeSession(session: IAgentSessionMetadata, mode: AgentHostExternalSessionsMode): boolean {
+		const key = session.session.toString();
+		if (!readSessionExternal(session._meta) || readSessionEhcliAdoptable(session._meta) || this._sessionsUsedByAgentHost.has(key) || this._stateManager.getSessionState(key)) {
+			return true;
+		}
+		switch (mode) {
+			case AgentHostExternalSessionsMode.All:
+				return true;
+			case AgentHostExternalSessionsMode.Last24Hours:
+				return session.modifiedTime >= this._now() - 24 * 60 * 60 * 1000;
+			case AgentHostExternalSessionsMode.Last7Days:
+				return session.modifiedTime >= this._now() - 7 * 24 * 60 * 60 * 1000;
+			case AgentHostExternalSessionsMode.None:
+				return false;
+		}
+	}
+
+	private _queueExternalSessionReconciliation(previousMode?: AgentHostExternalSessionsMode): void {
+		if (this._store.isDisposed) {
+			return;
+		}
+		this._externalSessionReconciliation = this._externalSessionReconciliation
+			.then(() => this._reconcileExternalSessions(previousMode))
+			.catch(error => this._logService.warn('[AgentService] External session reconciliation failed', error));
+	}
+
+	private async _reconcileExternalSessions(previousMode?: AgentHostExternalSessionsMode): Promise<void> {
+		const previouslyBroadcast = new Set(this._broadcastExternalSessions);
+		const previousMetadata = new Map(this._broadcastExternalSessionMetadata);
+		if (previouslyBroadcast.size === 0 && previousMode !== undefined) {
+			for (const session of await this.listSessions(previousMode, true, true)) {
+				if (readSessionExternal(session._meta)) {
+					const key = session.session.toString();
+					previouslyBroadcast.add(key);
+					previousMetadata.set(key, session);
+				}
+			}
+		}
+
+		const listed = await this.listSessions(this._externalSessionsMode, true, true);
+		const visible = new Map<string, IAgentSessionMetadata>();
+		for (const session of listed) {
+			if (readSessionExternal(session._meta)) {
+				visible.set(session.session.toString(), session);
+			}
+		}
+		this._scheduleExternalSessionExpiry(listed, this._externalSessionsMode);
+
+		for (const [key, metadata] of visible) {
+			if (!previouslyBroadcast.has(key)) {
+				const liveSummary = this._stateManager.getSessionSummary(key);
+				if (liveSummary) {
+					this._stateManager.markSessionPersisted(key, liveSummary, true);
+					continue;
+				}
+				const provider = AgentSession.provider(metadata.session);
+				if (provider) {
+					await this._announceSurfacedSession(metadata, provider);
+				}
+			}
+		}
+
+		for (const key of previouslyBroadcast) {
+			if (!visible.has(key) && !this._stateManager.getSessionState(key)) {
+				this._stateManager.retractSurfacedSession(key);
+				this._announcedSurfacedKeys.delete(key);
+			} else if (!visible.has(key)) {
+				const metadata = previousMetadata.get(key);
+				if (metadata) {
+					visible.set(key, metadata);
+				}
+			}
+		}
+
+		this._broadcastExternalSessions.clear();
+		this._broadcastExternalSessionMetadata.clear();
+		for (const [key, metadata] of visible) {
+			this._broadcastExternalSessions.add(key);
+			this._broadcastExternalSessionMetadata.set(key, metadata);
+		}
+	}
+
+	private _scheduleExternalSessionExpiry(sessions: readonly IAgentSessionMetadata[], mode: AgentHostExternalSessionsMode): void {
+		if (this._store.isDisposed) {
+			return;
+		}
+		const window = mode === AgentHostExternalSessionsMode.Last24Hours
+			? 24 * 60 * 60 * 1000
+			: mode === AgentHostExternalSessionsMode.Last7Days
+				? 7 * 24 * 60 * 60 * 1000
+				: undefined;
+		if (window === undefined) {
+			this._externalSessionExpiry.clear();
+			this._externalSessionExpiryAt = undefined;
+			return;
+		}
+
+		let nextExpiry: number | undefined;
+		for (const session of sessions) {
+			const key = session.session.toString();
+			if (!readSessionExternal(session._meta) || readSessionEhcliAdoptable(session._meta) || this._sessionsUsedByAgentHost.has(key) || this._stateManager.getSessionState(key)) {
+				continue;
+			}
+			const expiresAt = session.modifiedTime + window + 1;
+			nextExpiry = nextExpiry === undefined ? expiresAt : Math.min(nextExpiry, expiresAt);
+		}
+		this._scheduleExternalSessionExpiryAt(nextExpiry);
+	}
+
+	private _scheduleAdditionalExternalSessionExpiry(session: IAgentSessionMetadata): void {
+		const window = this._externalSessionsMode === AgentHostExternalSessionsMode.Last24Hours
+			? 24 * 60 * 60 * 1000
+			: this._externalSessionsMode === AgentHostExternalSessionsMode.Last7Days
+				? 7 * 24 * 60 * 60 * 1000
+				: undefined;
+		if (window === undefined || readSessionEhcliAdoptable(session._meta) || this._sessionsUsedByAgentHost.has(session.session.toString())) {
+			return;
+		}
+		const expiresAt = session.modifiedTime + window + 1;
+		if (this._externalSessionExpiryAt === undefined || expiresAt < this._externalSessionExpiryAt) {
+			this._scheduleExternalSessionExpiryAt(expiresAt);
+		}
+	}
+
+	private _scheduleExternalSessionExpiryAt(expiresAt: number | undefined): void {
+		if (this._store.isDisposed) {
+			return;
+		}
+		this._externalSessionExpiryAt = expiresAt;
+		this._externalSessionExpiry.value = expiresAt === undefined
+			? undefined
+			: disposableTimeout(() => {
+				this._externalSessionExpiryAt = undefined;
+				this._queueExternalSessionReconciliation();
+			}, Math.max(0, expiresAt - this._now()));
 	}
 
 	/**
@@ -1589,6 +1802,9 @@ export class AgentService extends Disposable implements IAgentService {
 
 	private async _announceSurfacedSession(meta: IAgentSessionMetadata, provider: string): Promise<void> {
 		const key = meta.session.toString();
+		if (!this._shouldIncludeSession(meta, this._externalSessionsMode)) {
+			return;
+		}
 		if (this._announcedSurfacedKeys.has(key) || this._stateManager.getSessionState(key)) {
 			return;
 		}
@@ -3190,7 +3406,19 @@ export class AgentService extends Disposable implements IAgentService {
 			this._stateManager.removeSession(cachedKey);
 		}
 		this._sideEffects.clearSessionTitleState(evictionTargetKey, settledState.chats.map(chat => chat.resource));
+		const evictedSummary = this._stateManager.getSessionSummary(evictionTargetKey);
+		const evictedMetadata: IAgentSessionMetadata | undefined = evictedSummary ? {
+			session: evictionTarget,
+			startTime: Date.parse(evictedSummary.createdAt),
+			modifiedTime: Date.parse(evictedSummary.modifiedAt),
+			...(evictedSummary._meta !== undefined ? { _meta: evictedSummary._meta } : {}),
+		} : undefined;
 		this._stateManager.removeSession(evictionTargetKey);
+		if (evictedMetadata && !this._shouldIncludeSession(evictedMetadata, this._externalSessionsMode)) {
+			this._queueExternalSessionReconciliation();
+		} else if (evictedMetadata && readSessionExternal(evictedMetadata._meta)) {
+			this._scheduleAdditionalExternalSessionExpiry(evictedMetadata);
+		}
 		// Release the provider's in-memory SDK session in lockstep with the
 		// cached state. Non-destructive: durable data is preserved so the
 		// session resumes transparently on the next access. Fire-and-forget —
@@ -3384,6 +3612,9 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 		}
 		this._stateManager.dispatchClientAction(channel, action, origin);
+		if (action.type === ActionType.ChatTurnStarted) {
+			this._markSessionUsedByAgentHost(sessionChannel);
+		}
 		if (action.type === ActionType.RootConfigChanged) {
 			this._configurationService.persistRootConfig();
 			const editTelemetryEnabled = action.config[AgentHostEditTelemetryEnabledConfigKey];
@@ -3393,6 +3624,47 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		this._sideEffects.handleAction(channel, action, clientId, clientContext);
 	}
+
+	private _markSessionUsedByAgentHost(session: string): void {
+		this._sessionsUsedByAgentHost.add(session);
+		if (this._sessionUsePersistence.has(session)) {
+			return;
+		}
+		const summary = this._stateManager.getSessionSummary(session);
+		if (!summary || !readSessionExternal(summary._meta)) {
+			return;
+		}
+
+		const sessionUri = URI.parse(session);
+		const persistence = this._retryRegistryMutation(
+			() => this._sessionRegistry.register(sessionUri, {
+				provider: summary.provider,
+				startTime: Date.parse(summary.createdAt),
+				source: 'explicit',
+			}, { checkTombstone: true }),
+			`used-state registration for ${session}`,
+		).then(registered => {
+			if (!registered) {
+				throw new Error(`Session was tombstoned while marking it used: ${session}`);
+			}
+			const state = this._stateManager.getSessionState(session);
+			if (state && readSessionExternal(state._meta)) {
+				this._stateManager.setSessionMeta(session, withSessionExternal(state._meta, false));
+			}
+			this._queueExternalSessionReconciliation();
+		});
+		this._sessionUsePersistence.set(session, persistence);
+		const clear = () => {
+			if (this._sessionUsePersistence.get(session) === persistence) {
+				this._sessionUsePersistence.delete(session);
+			}
+		};
+		void persistence.then(clear, error => {
+			clear();
+			this._logService.warn(`[AgentService] Failed to persist used state for ${session}`, error);
+		});
+	}
+
 	private _getUnresolvedPeerChats(sessionChannel: string): readonly string[] | undefined {
 		return this._stateManager.getSessionState(sessionChannel)?.chats.filter(chat => !isDefaultChatUri(chat.resource) && !this._stateManager.getChatState(chat.resource)).map(chat => chat.resource);
 	}
@@ -3890,6 +4162,9 @@ export class AgentService extends Disposable implements IAgentService {
 		if (isArchived) {
 			status |= SessionStatus.IsArchived;
 		}
+		if (external && !this._sessionsUsedByAgentHost.has(sessionStr)) {
+			status |= SessionStatus.IsRead;
+		}
 
 		const providerMeta = withSessionMultiRootMetadata(meta._meta, undefined);
 		let restoredMeta = (sessionMetadata || providerMeta) ? { ...(providerMeta ?? {}), ...(sessionMetadata ?? {}) } : undefined;
@@ -3928,6 +4203,9 @@ export class AgentService extends Disposable implements IAgentService {
 			throw new ProtocolError(AHP_SESSION_NOT_FOUND, `Session was explicitly deleted: ${sessionStr}`);
 		}
 		this._stateManager.restoreSession(summary, mergedTurns, { draft: restoredDraft, defaultChatTitle });
+		if (external) {
+			this._queueExternalSessionReconciliation();
+		}
 
 		// A freshly-adopted legacy session bridges its git checkpoints into the
 		// agent-host namespace once its turns are restored. Isolated so a failure

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -310,10 +310,7 @@ export class AgentService extends Disposable implements IAgentService {
 	private readonly _sessionsUsedByAgentHost = new Set<string>();
 	private readonly _sessionUsePersistence = new Map<string, Promise<void>>();
 	private readonly _discoveredSessionMetadata = new Map<string, IAgentSessionMetadata>();
-	private readonly _broadcastExternalSessions = new Set<string>();
-	private readonly _broadcastExternalSessionMetadata = new Map<string, IAgentSessionMetadata>();
-	private readonly _externalSessionExpiry = this._register(new MutableDisposable());
-	private _externalSessionExpiryAt: number | undefined;
+	private readonly _broadcastExternalSessions = new Map<string, IAgentSessionMetadata>();
 	private _externalSessionReconciliation = Promise.resolve();
 	private _externalSessionsMode = AgentHostExternalSessionsMode.Last7Days;
 
@@ -1665,26 +1662,24 @@ export class AgentService extends Disposable implements IAgentService {
 	}
 
 	private async _reconcileExternalSessions(previousMode?: AgentHostExternalSessionsMode): Promise<void> {
-		const previouslyBroadcast = new Set(this._broadcastExternalSessions);
-		const previousMetadata = new Map(this._broadcastExternalSessionMetadata);
+		const previouslyBroadcast = new Map(this._broadcastExternalSessions);
 		if (previouslyBroadcast.size === 0 && previousMode !== undefined) {
 			for (const session of await this.listSessions(previousMode, true, true)) {
 				if (readSessionExternal(session._meta)) {
 					const key = session.session.toString();
-					previouslyBroadcast.add(key);
-					previousMetadata.set(key, session);
+					previouslyBroadcast.set(key, session);
 				}
 			}
 		}
 
 		const listed = await this.listSessions(this._externalSessionsMode, true, true);
+		const listedKeys = new Set(listed.map(session => session.session.toString()));
 		const visible = new Map<string, IAgentSessionMetadata>();
 		for (const session of listed) {
 			if (readSessionExternal(session._meta)) {
 				visible.set(session.session.toString(), session);
 			}
 		}
-		this._scheduleExternalSessionExpiry(listed, this._externalSessionsMode);
 
 		for (const [key, metadata] of visible) {
 			if (!previouslyBroadcast.has(key)) {
@@ -1700,79 +1695,25 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 		}
 
-		for (const key of previouslyBroadcast) {
-			if (!visible.has(key) && !this._stateManager.getSessionState(key)) {
+		for (const [key, metadata] of previouslyBroadcast) {
+			if (visible.has(key)) {
+				continue;
+			}
+			if (listedKeys.has(key)) {
+				continue;
+			}
+			if (previousMode !== undefined && !this._stateManager.getSessionState(key)) {
 				this._stateManager.retractSurfacedSession(key);
 				this._announcedSurfacedKeys.delete(key);
-			} else if (!visible.has(key)) {
-				const metadata = previousMetadata.get(key);
-				if (metadata) {
-					visible.set(key, metadata);
-				}
+			} else {
+				visible.set(key, metadata);
 			}
 		}
 
 		this._broadcastExternalSessions.clear();
-		this._broadcastExternalSessionMetadata.clear();
 		for (const [key, metadata] of visible) {
-			this._broadcastExternalSessions.add(key);
-			this._broadcastExternalSessionMetadata.set(key, metadata);
+			this._broadcastExternalSessions.set(key, metadata);
 		}
-	}
-
-	private _scheduleExternalSessionExpiry(sessions: readonly IAgentSessionMetadata[], mode: AgentHostExternalSessionsMode): void {
-		if (this._store.isDisposed) {
-			return;
-		}
-		const window = mode === AgentHostExternalSessionsMode.Last24Hours
-			? 24 * 60 * 60 * 1000
-			: mode === AgentHostExternalSessionsMode.Last7Days
-				? 7 * 24 * 60 * 60 * 1000
-				: undefined;
-		if (window === undefined) {
-			this._externalSessionExpiry.clear();
-			this._externalSessionExpiryAt = undefined;
-			return;
-		}
-
-		let nextExpiry: number | undefined;
-		for (const session of sessions) {
-			const key = session.session.toString();
-			if (!readSessionExternal(session._meta) || readSessionEhcliAdoptable(session._meta) || this._sessionsUsedByAgentHost.has(key) || this._stateManager.getSessionState(key)) {
-				continue;
-			}
-			const expiresAt = session.modifiedTime + window + 1;
-			nextExpiry = nextExpiry === undefined ? expiresAt : Math.min(nextExpiry, expiresAt);
-		}
-		this._scheduleExternalSessionExpiryAt(nextExpiry);
-	}
-
-	private _scheduleAdditionalExternalSessionExpiry(session: IAgentSessionMetadata): void {
-		const window = this._externalSessionsMode === AgentHostExternalSessionsMode.Last24Hours
-			? 24 * 60 * 60 * 1000
-			: this._externalSessionsMode === AgentHostExternalSessionsMode.Last7Days
-				? 7 * 24 * 60 * 60 * 1000
-				: undefined;
-		if (window === undefined || readSessionEhcliAdoptable(session._meta) || this._sessionsUsedByAgentHost.has(session.session.toString())) {
-			return;
-		}
-		const expiresAt = session.modifiedTime + window + 1;
-		if (this._externalSessionExpiryAt === undefined || expiresAt < this._externalSessionExpiryAt) {
-			this._scheduleExternalSessionExpiryAt(expiresAt);
-		}
-	}
-
-	private _scheduleExternalSessionExpiryAt(expiresAt: number | undefined): void {
-		if (this._store.isDisposed) {
-			return;
-		}
-		this._externalSessionExpiryAt = expiresAt;
-		this._externalSessionExpiry.value = expiresAt === undefined
-			? undefined
-			: disposableTimeout(() => {
-				this._externalSessionExpiryAt = undefined;
-				this._queueExternalSessionReconciliation();
-			}, Math.max(0, expiresAt - this._now()));
 	}
 
 	/**
@@ -3065,6 +3006,10 @@ export class AgentService extends Disposable implements IAgentService {
 		this._sideEffects.clearInputRequestsForSession(session.toString());
 		// Remove all subagent sessions for this parent
 		this._sideEffects.removeSubagentSessions(session.toString());
+		this._broadcastExternalSessions.delete(session.toString());
+		this._discoveredSessionMetadata.delete(session.toString());
+		this._sessionsUsedByAgentHost.delete(session.toString());
+		this._announcedSurfacedKeys.delete(session.toString());
 		this._stateManager.deleteSession(session.toString());
 	}
 
@@ -3406,19 +3351,7 @@ export class AgentService extends Disposable implements IAgentService {
 			this._stateManager.removeSession(cachedKey);
 		}
 		this._sideEffects.clearSessionTitleState(evictionTargetKey, settledState.chats.map(chat => chat.resource));
-		const evictedSummary = this._stateManager.getSessionSummary(evictionTargetKey);
-		const evictedMetadata: IAgentSessionMetadata | undefined = evictedSummary ? {
-			session: evictionTarget,
-			startTime: Date.parse(evictedSummary.createdAt),
-			modifiedTime: Date.parse(evictedSummary.modifiedAt),
-			...(evictedSummary._meta !== undefined ? { _meta: evictedSummary._meta } : {}),
-		} : undefined;
 		this._stateManager.removeSession(evictionTargetKey);
-		if (evictedMetadata && !this._shouldIncludeSession(evictedMetadata, this._externalSessionsMode)) {
-			this._queueExternalSessionReconciliation();
-		} else if (evictedMetadata && readSessionExternal(evictedMetadata._meta)) {
-			this._scheduleAdditionalExternalSessionExpiry(evictedMetadata);
-		}
 		// Release the provider's in-memory SDK session in lockstep with the
 		// cached state. Non-destructive: durable data is preserved so the
 		// session resumes transparently on the next access. Fire-and-forget —

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -235,6 +235,12 @@ interface IProviderDiscoveryState {
 	forceQueued: boolean;
 }
 
+interface IAgentSessionListResult {
+	readonly sessions: IAgentSessionMetadata[];
+	readonly unevaluatedExternalSessions: ReadonlySet<string>;
+	readonly nonExternalSessions: ReadonlySet<string>;
+}
+
 /**
  * Reconcile a session's working-directory set from a create-result /
  * materialization receipt. The resolved receipt is authoritative for the roots
@@ -309,8 +315,8 @@ export class AgentService extends Disposable implements IAgentService {
 	private readonly _unpersistedChatBackings = new Set<string>();
 	private readonly _sessionsUsedByAgentHost = new Set<string>();
 	private readonly _sessionUsePersistence = new Map<string, Promise<void>>();
-	private readonly _discoveredSessionMetadata = new Map<string, IAgentSessionMetadata>();
 	private readonly _broadcastExternalSessions = new Map<string, IAgentSessionMetadata>();
+	private _broadcastExternalSessionsSeeded = false;
 	private _externalSessionReconciliation = Promise.resolve();
 	private _externalSessionsMode = AgentHostExternalSessionsMode.Last7Days;
 
@@ -1254,15 +1260,7 @@ export class AgentService extends Disposable implements IAgentService {
 			changed = registered || changed;
 		}
 		if (surfaced.length > 0) {
-			const authoritative = new Map((await this._listRegisteredSessions()).map(entry => [entry.session.toString(), entry]));
-			for (const { identity, metadata } of surfaced) {
-				const external = authoritative.get(identity.session.toString())?.external ?? identity.external;
-				const surfacedMetadata = { ...metadata, _meta: withSessionExternal(metadata._meta, external) };
-				this._discoveredSessionMetadata.set(identity.session.toString(), surfacedMetadata);
-				if (!external || readSessionEhcliAdoptable(metadata._meta)) {
-					await this._announceSurfacedSession(surfacedMetadata, provider.id);
-				}
-			}
+			await this._surfaceRegisteredSessions(provider, surfaced);
 		}
 		if (changed) {
 			this._queueExternalSessionReconciliation();
@@ -1306,19 +1304,21 @@ export class AgentService extends Disposable implements IAgentService {
 			changed = registered || changed;
 		}
 		if (surfaced.length > 0) {
-			const authoritative = new Map((await this._listRegisteredSessions()).map(entry => [entry.session.toString(), entry]));
-			for (const { identity, metadata } of surfaced) {
-				const external = authoritative.get(identity.session.toString())?.external ?? identity.external;
-				const surfacedMetadata = { ...metadata, _meta: withSessionExternal(metadata._meta, external) };
-				this._discoveredSessionMetadata.set(identity.session.toString(), surfacedMetadata);
-				if (!external || readSessionEhcliAdoptable(metadata._meta)) {
-					await this._announceSurfacedSession(surfacedMetadata, provider.id);
-				}
-			}
+			await this._surfaceRegisteredSessions(provider, surfaced);
 		}
 		await this._sessionRegistry.markProviderBackfilled(provider.id);
 		if (changed) {
 			this._queueExternalSessionReconciliation();
+		}
+	}
+
+	private async _surfaceRegisteredSessions(provider: IAgent, sessions: readonly { readonly identity: IRegisteredSession; readonly metadata: IAgentSessionMetadata }[]): Promise<void> {
+		const authoritative = new Map((await this._listRegisteredSessions()).map(entry => [entry.session.toString(), entry]));
+		for (const { identity, metadata } of sessions) {
+			const external = authoritative.get(identity.session.toString())?.external ?? identity.external;
+			if (!external || readSessionEhcliAdoptable(metadata._meta)) {
+				await this._announceSurfacedSession({ ...metadata, _meta: withSessionExternal(metadata._meta, external) }, provider.id);
+			}
 		}
 	}
 
@@ -1384,15 +1384,10 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 	}
 	async listSessions(): Promise<IAgentSessionMetadata[]> {
-		return this._listSessions({ mode: this._externalSessionsMode });
+		return (await this._listSessions(this._externalSessionsMode)).sessions;
 	}
 
-	private async _listSessions(options: {
-		readonly mode: AgentHostExternalSessionsMode;
-		readonly preferLiveState?: boolean;
-		readonly preferDiscoveredMetadata?: boolean;
-	}): Promise<IAgentSessionMetadata[]> {
-		const { mode, preferLiveState = false, preferDiscoveredMetadata = false } = options;
+	private async _listSessions(mode: AgentHostExternalSessionsMode, skipManagedSessions = false): Promise<IAgentSessionListResult> {
 		this._logService.trace('[AgentService] listSessions called');
 		// The first list waits for registration-time discovery if it is still in flight.
 		await this._awaitInitialProviderDiscovery();
@@ -1400,6 +1395,8 @@ export class AgentService extends Disposable implements IAgentService {
 		// chat backings and subagent sessions never enter it, and a transiently
 		// missing provider snapshot no longer evicts a session.
 		const registered = await this._listRegisteredSessions();
+		const unevaluatedExternalSessions = new Set<string>();
+		const nonExternalSessions = new Set(registered.filter(session => !session.external).map(session => session.session.toString()));
 		const metadataLimiter = new Limiter<IAgentSessionMetadata | undefined>(4);
 		const results = await Promise.all(registered.map(registeredSession => metadataLimiter.queue(async (): Promise<IAgentSessionMetadata | undefined> => {
 			const { session, provider, external } = registeredSession;
@@ -1409,24 +1406,37 @@ export class AgentService extends Disposable implements IAgentService {
 			if (this._stateManager.isIdleProvisionalSession(session.toString())) {
 				return undefined;
 			}
-			if (preferLiveState && this._stateManager.getSessionState(session.toString())) {
-				return undefined;
-			}
-			if (preferDiscoveredMetadata) {
-				const discovered = this._discoveredSessionMetadata.get(session.toString());
-				if (discovered) {
-					return { ...discovered, _meta: withSessionExternal(discovered._meta, external) };
+			const sessionKey = session.toString();
+			if (skipManagedSessions && (
+				this._stateManager.getSessionState(sessionKey)
+				|| this._releaseSessionInFlight.has(sessionKey)
+				|| this._restoreSessionInFlight.has(sessionKey)
+			)) {
+				if (external) {
+					unevaluatedExternalSessions.add(sessionKey);
 				}
+				return undefined;
 			}
 
 			const agent = this._providers.get(provider);
 			if (!agent) {
+				if (external) {
+					unevaluatedExternalSessions.add(sessionKey);
+				}
 				return undefined;
 			}
 			try {
-				return await this._registeredSessionMetadata(agent, session, external);
+				const metadata = await this._registeredSessionMetadata(agent, session, external);
+				if (!metadata && external) {
+					// Missing provider metadata is not an authoritative session removal.
+					unevaluatedExternalSessions.add(sessionKey);
+				}
+				return metadata;
 			} catch (err) {
 				this._logService.warn(`[AgentService] listSessions: failed to read metadata for ${session}`, err);
+				if (external) {
+					unevaluatedExternalSessions.add(sessionKey);
+				}
 				return undefined;
 			}
 		})));
@@ -1627,7 +1637,7 @@ export class AgentService extends Disposable implements IAgentService {
 			.filter(session => this._shouldIncludeSession(session, mode));
 
 		this._logService.trace(`[AgentService] listSessions returned ${visible.length} sessions (${additions.length} state-manager fallback)`);
-		return visible;
+		return { sessions: visible, unevaluatedExternalSessions, nonExternalSessions };
 	}
 
 	private _forceUnusedExternalSessionRead(session: IAgentSessionMetadata): IAgentSessionMetadata {
@@ -1671,18 +1681,26 @@ export class AgentService extends Disposable implements IAgentService {
 	}
 
 	private async _reconcileExternalSessions(previousMode?: AgentHostExternalSessionsMode): Promise<void> {
+		if (this._store.isDisposed) {
+			return;
+		}
 		const previouslyBroadcast = new Map(this._broadcastExternalSessions);
-		if (previouslyBroadcast.size === 0 && previousMode !== undefined) {
-			for (const session of await this._listSessions({ mode: previousMode, preferLiveState: true, preferDiscoveredMetadata: true })) {
+		if (!this._broadcastExternalSessionsSeeded && previousMode !== undefined) {
+			for (const session of (await this._listSessions(previousMode, true)).sessions) {
 				if (readSessionExternal(session._meta)) {
 					const key = session.session.toString();
 					previouslyBroadcast.set(key, session);
 				}
 			}
+			if (this._store.isDisposed) {
+				return;
+			}
 		}
 
-		const listed = await this._listSessions({ mode: this._externalSessionsMode, preferLiveState: true, preferDiscoveredMetadata: true });
-		const listedKeys = new Set(listed.map(session => session.session.toString()));
+		const { sessions: listed, unevaluatedExternalSessions, nonExternalSessions } = await this._listSessions(this._externalSessionsMode, true);
+		if (this._store.isDisposed) {
+			return;
+		}
 		const visible = new Map<string, IAgentSessionMetadata>();
 		for (const session of listed) {
 			if (readSessionExternal(session._meta)) {
@@ -1691,10 +1709,13 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 
 		for (const [key, metadata] of visible) {
+			if (this._store.isDisposed) {
+				return;
+			}
 			if (!previouslyBroadcast.has(key)) {
 				const liveSummary = this._stateManager.getSessionSummary(key);
 				if (liveSummary) {
-					this._stateManager.markSessionPersisted(key, liveSummary, true);
+					this._stateManager.announceLiveSession(key);
 					continue;
 				}
 				const provider = AgentSession.provider(metadata.session);
@@ -1708,7 +1729,11 @@ export class AgentService extends Disposable implements IAgentService {
 			if (visible.has(key)) {
 				continue;
 			}
-			if (listedKeys.has(key)) {
+			if (nonExternalSessions.has(key)) {
+				continue;
+			}
+			if (unevaluatedExternalSessions.has(key)) {
+				visible.set(key, metadata);
 				continue;
 			}
 			if (previousMode !== undefined && !this._stateManager.getSessionState(key)) {
@@ -1723,6 +1748,7 @@ export class AgentService extends Disposable implements IAgentService {
 		for (const [key, metadata] of visible) {
 			this._broadcastExternalSessions.set(key, metadata);
 		}
+		this._broadcastExternalSessionsSeeded = true;
 	}
 
 	/**
@@ -1751,6 +1777,9 @@ export class AgentService extends Disposable implements IAgentService {
 	private readonly _announcedSurfacedKeys = new Set<string>();
 
 	private async _announceSurfacedSession(meta: IAgentSessionMetadata, provider: string): Promise<void> {
+		if (this._store.isDisposed) {
+			return;
+		}
 		const key = meta.session.toString();
 		if (!this._shouldIncludeSession(meta, this._externalSessionsMode)) {
 			return;
@@ -1760,6 +1789,10 @@ export class AgentService extends Disposable implements IAgentService {
 		}
 		this._announcedSurfacedKeys.add(key);
 		if (await this._sessionRegistry.isTombstoned(meta.session)) {
+			this._announcedSurfacedKeys.delete(key);
+			return;
+		}
+		if (this._store.isDisposed) {
 			this._announcedSurfacedKeys.delete(key);
 			return;
 		}
@@ -3016,7 +3049,6 @@ export class AgentService extends Disposable implements IAgentService {
 		// Remove all subagent sessions for this parent
 		this._sideEffects.removeSubagentSessions(session.toString());
 		this._broadcastExternalSessions.delete(session.toString());
-		this._discoveredSessionMetadata.delete(session.toString());
 		this._sessionsUsedByAgentHost.delete(session.toString());
 		this._announcedSurfacedKeys.delete(session.toString());
 		this._stateManager.deleteSession(session.toString());
@@ -3553,8 +3585,8 @@ export class AgentService extends Disposable implements IAgentService {
 				return;
 			}
 		}
-		this._stateManager.dispatchClientAction(channel, action, origin);
-		if (action.type === ActionType.ChatTurnStarted) {
+		const resultingState = this._stateManager.dispatchClientAction(channel, action, origin);
+		if (action.type === ActionType.ChatTurnStarted && resultingState !== undefined) {
 			this._markSessionUsedByAgentHost(sessionChannel);
 		}
 		if (action.type === ActionType.RootConfigChanged) {

--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -1383,7 +1383,16 @@ export class AgentService extends Disposable implements IAgentService {
 			return false;
 		}
 	}
-	async listSessions(mode = this._externalSessionsMode, preferLiveState = false, preferDiscoveredMetadata = false): Promise<IAgentSessionMetadata[]> {
+	async listSessions(): Promise<IAgentSessionMetadata[]> {
+		return this._listSessions({ mode: this._externalSessionsMode });
+	}
+
+	private async _listSessions(options: {
+		readonly mode: AgentHostExternalSessionsMode;
+		readonly preferLiveState?: boolean;
+		readonly preferDiscoveredMetadata?: boolean;
+	}): Promise<IAgentSessionMetadata[]> {
+		const { mode, preferLiveState = false, preferDiscoveredMetadata = false } = options;
 		this._logService.trace('[AgentService] listSessions called');
 		// The first list waits for registration-time discovery if it is still in flight.
 		await this._awaitInitialProviderDiscovery();
@@ -1664,7 +1673,7 @@ export class AgentService extends Disposable implements IAgentService {
 	private async _reconcileExternalSessions(previousMode?: AgentHostExternalSessionsMode): Promise<void> {
 		const previouslyBroadcast = new Map(this._broadcastExternalSessions);
 		if (previouslyBroadcast.size === 0 && previousMode !== undefined) {
-			for (const session of await this.listSessions(previousMode, true, true)) {
+			for (const session of await this._listSessions({ mode: previousMode, preferLiveState: true, preferDiscoveredMetadata: true })) {
 				if (readSessionExternal(session._meta)) {
 					const key = session.session.toString();
 					previouslyBroadcast.set(key, session);
@@ -1672,7 +1681,7 @@ export class AgentService extends Disposable implements IAgentService {
 			}
 		}
 
-		const listed = await this.listSessions(this._externalSessionsMode, true, true);
+		const listed = await this._listSessions({ mode: this._externalSessionsMode, preferLiveState: true, preferDiscoveredMetadata: true });
 		const listedKeys = new Set(listed.map(session => session.session.toString()));
 		const visible = new Map<string, IAgentSessionMetadata>();
 		for (const session of listed) {

--- a/src/vs/platform/agentHost/node/agentSessionRegistry.ts
+++ b/src/vs/platform/agentHost/node/agentSessionRegistry.ts
@@ -15,7 +15,7 @@ export interface IRegisteredSession {
 	readonly provider: AgentProvider;
 	/** Session creation time (ms since epoch) as first observed by the orchestrator. */
 	readonly startTime: number;
-	/** Whether the session was first discovered from the provider's native catalog. */
+	/** Whether the session remains provider-native and has not been explicitly used through Agent Host. */
 	readonly external: boolean;
 	/** Durable registration source used to protect external provenance. */
 	readonly source: AgentSessionRegistrationSource;

--- a/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
@@ -283,6 +283,21 @@ suite('AgentHostStateManager', () => {
 		assert.strictEqual(notifications[0].type, NotificationType.SessionAdded);
 	});
 
+	test('announceLiveSession re-announces the current live summary', () => {
+		const notifications: INotification[] = [];
+		disposables.add(manager.onDidEmitNotification(notification => notifications.push(notification)));
+		const summary = makeSessionSummary();
+		manager.restoreSession(summary, []);
+
+		manager.announceLiveSession(sessionUri);
+
+		assert.deepStrictEqual(notifications, [{
+			type: NotificationType.SessionAdded,
+			channel: ROOT_STATE_URI,
+			summary,
+		}]);
+	});
+
 	test('retractSurfacedSession emits a protocol URI only for non-live sessions', () => {
 		const notifications: INotification[] = [];
 		disposables.add(manager.onDidEmitNotification(notification => notifications.push(notification)));

--- a/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts
@@ -283,6 +283,31 @@ suite('AgentHostStateManager', () => {
 		assert.strictEqual(notifications[0].type, NotificationType.SessionAdded);
 	});
 
+	test('retractSurfacedSession emits a protocol URI only for non-live sessions', () => {
+		const notifications: INotification[] = [];
+		disposables.add(manager.onDidEmitNotification(notification => notifications.push(notification)));
+		manager.announceSurfacedSession(makeSessionSummary());
+		notifications.length = 0;
+
+		manager.retractSurfacedSession(sessionUri);
+		const removed = notifications[0];
+		manager.createSession(makeSessionSummary());
+		notifications.length = 0;
+		manager.retractSurfacedSession(sessionUri);
+
+		assert.deepStrictEqual({
+			removed: removed?.type === NotificationType.SessionRemoved ? removed.session : undefined,
+			surfaced: manager.getSurfacedSessionSummary(sessionUri),
+			live: manager.getSessionState(sessionUri) !== undefined,
+			liveNotifications: notifications,
+		}, {
+			removed: sessionUri,
+			surfaced: undefined,
+			live: true,
+			liveNotifications: [],
+		});
+	});
+
 	test('default chat inherits the session working directory resolved at materialization', () => {
 		// A deferred (provisional) session is created with a pre-materialization
 		// working directory; materialization later resolves it to a different

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -30,7 +30,8 @@ import { InMemoryFileSystemProvider } from '../../../files/common/inMemoryFilesy
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, SubagentChatSignal, resolveAgentChatContext, type IAgent, type IAgentChatAdoptionResult, type IAgentChatContext, type IAgentChatDataChange, type IAgentChatMetadata, type IAgentChats, type IAgentCreateChatForkSource, type IAgentCreateChatOptions, type IAgentCreateChatResult, type IAgentCreateSessionConfig, type IAgentCreateSessionResult, type IAgentDescriptor, type IAgentDiscoveredChat, type IAgentLegacyChat, type IAgentMaterializeChatEvent, type IAgentSessionMetadata, type IAgentSpawnChatEvent } from '../../common/agent.js';
 import { IConnectionTrackerService } from '../../common/agentService.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
-import { AgentHostActiveAgentTitleGenerationConfigKey } from '../../common/agentHostSchema.js';
+import { AgentHostActiveAgentTitleGenerationConfigKey, AgentHostExternalSessionsMode, AgentHostShowExternalSessionsConfigKey } from '../../common/agentHostSchema.js';
+import { AgentHostLaunchKind } from '../../common/agentHostTelemetry.js';
 import { ClaudeSessionConfigKey } from '../../common/claudeSessionConfigKeys.js';
 import { CodexSessionConfigKey } from '../../common/codexSessionConfigKeys.js';
 import { ISessionDatabase, ISessionDataService } from '../../common/sessionDataService.js';
@@ -217,6 +218,7 @@ class TransientRegistryWriteDatabase implements IAgentHostDatabase {
 	registryWriteAttempts = 0;
 	private _remainingRegistryWriteFailures = 0;
 	private readonly _sessionsWithoutExternal = new Set<string>();
+	private _registryWriteGate: DeferredPromise<void> | undefined;
 	readonly externalUpdates: { session: string; external: boolean }[] = [];
 	undefinedExternalListCalls = 0;
 
@@ -230,19 +232,34 @@ class TransientRegistryWriteDatabase implements IAgentHostDatabase {
 		this._remainingRegistryWriteFailures = count;
 	}
 
+	pauseRegistryWrites(): DeferredPromise<void> {
+		return this._registryWriteGate = new DeferredPromise<void>();
+	}
+
 	async registerSession(session: string, sessionOptions: { provider: string; startTime: number; source: 'explicit' | 'restore' | 'discovery' }, registerOptions: { checkTombstone: boolean }): Promise<boolean> {
 		this._beforeWrite();
+		const gate = this._registryWriteGate;
+		if (gate) {
+			await gate.p;
+			if (this._registryWriteGate === gate) {
+				this._registryWriteGate = undefined;
+			}
+		}
 		if (registerOptions.checkTombstone && this._tombstones.has(session)) {
 			return false;
 		}
 		const { provider, startTime, source } = sessionOptions;
 		const existing = this._sessions.get(session);
 		const inserted = { session, provider, startTime, external: source === 'discovery', source };
-		this._sessions.set(session, source === 'explicit'
-			? { ...inserted, startTime: existing?.startTime ?? startTime }
-			: existing && source === 'discovery'
-				? { ...existing, external: true, source: 'discovery' }
-				: existing ?? inserted);
+		this._sessions.set(session, !existing
+			? inserted
+			: source === 'explicit'
+				? { ...existing, provider, external: false, source: 'explicit' }
+				: source === 'restore'
+					? { ...existing, external: false, source: existing.source === 'explicit' ? 'explicit' : 'restore' }
+					: existing.source === 'explicit'
+						? existing
+						: { ...existing, external: true, source: 'discovery' });
 		if (!registerOptions.checkTombstone) {
 			this._tombstones.delete(session);
 		}
@@ -2456,6 +2473,82 @@ suite('AgentService (node dispatcher)', () => {
 
 	suite('aggregation', () => {
 
+		class ExternalCatalogAgent extends MockAgent {
+			private readonly _catalog = new Map<string, { session: URI; modifiedTime: number; external: boolean; status?: SessionStatus }>();
+
+			addSession(id: string, modifiedTime: number, external = true, status?: SessionStatus): URI {
+				const session = AgentSession.uri(this.id, id);
+				this._catalog.set(id, { session, modifiedTime, external, status });
+				(this as unknown as { _sessions: Map<string, URI> })._sessions.set(id, session);
+				return session;
+			}
+
+			fireCatalog(...ids: string[]): void {
+				const entries = ids.length > 0 ? ids.map(id => this._catalog.get(id)) : [...this._catalog.values()];
+				this.fireDiscoveredChats(entries.filter(entry => entry !== undefined).map(entry => ({
+					chat: URI.parse(buildDefaultChatUri(entry.session)),
+					startTime: entry.modifiedTime,
+					modifiedTime: entry.modifiedTime,
+					external: entry.external,
+					status: entry.status,
+				})));
+			}
+
+			override async listExternalChats(): Promise<IAgentChatMetadata[]> {
+				return [];
+			}
+
+			override async getChatMetadata(chat: URI, context: URI | IAgentChatContext): Promise<IAgentChatMetadata | undefined> {
+				const session = resolveAgentChatContext(context, chat).configurationResource;
+				const entry = this._catalog.get(AgentSession.id(session));
+				return entry ? {
+					chat,
+					startTime: entry.modifiedTime,
+					modifiedTime: entry.modifiedTime,
+					status: entry.status,
+				} : undefined;
+			}
+		}
+
+		function createExternalSessionService(now: () => number, database?: IAgentHostDatabase): AgentService {
+			return disposables.add(new AgentService(
+				new NullLogService(),
+				fileService,
+				createSessionDataService(),
+				{ _serviceBrand: undefined } as IProductService,
+				createNoopGitService(),
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				[],
+				AgentHostLaunchKind.Unknown,
+				database,
+				now,
+			));
+		}
+
+		let externalConfigSequence = 0;
+		function setExternalSessionsMode(service: AgentService, mode: AgentHostExternalSessionsMode): void {
+			service.dispatchAction(ROOT_STATE_URI, {
+				type: ActionType.RootConfigChanged,
+				config: { [AgentHostShowExternalSessionsConfigKey]: mode },
+			}, 'external-config-test', ++externalConfigSequence);
+		}
+
+		async function waitForExternalReconciliation(service: AgentService): Promise<void> {
+			await timeout(0);
+			await (service as unknown as { _externalSessionReconciliation: Promise<void> })._externalSessionReconciliation;
+		}
+
+		async function waitForRegisteredSessions(service: AgentService, count: number): Promise<void> {
+			for (let attempt = 0; attempt < 50 && (await service.getRegisteredSessions()).length < count; attempt++) {
+				await timeout(0);
+			}
+			assert.strictEqual((await service.getRegisteredSessions()).length, count);
+		}
+
 		test('listSessions aggregates sessions from all providers', async () => {
 			service.registerProvider(copilotAgent);
 
@@ -2463,6 +2556,293 @@ suite('AgentService (node dispatcher)', () => {
 
 			const sessions = await service.listSessions();
 			assert.strictEqual(sessions.length, 1);
+		});
+
+		test('filters authoritative external sessions in all modes with inclusive boundaries', async () => {
+			const day = 24 * 60 * 60 * 1000;
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			agent.addSession('internal', now - 30 * day, false);
+			agent.addSession('recent', now);
+			agent.addSession('at-24-hours', now - day);
+			agent.addSession('older-than-24-hours', now - day - 1);
+			agent.addSession('at-7-days', now - 7 * day);
+			agent.addSession('older-than-7-days', now - 7 * day - 1);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			agent.fireCatalog();
+			await waitForRegisteredSessions(svc, 6);
+			await waitForExternalReconciliation(svc);
+
+			const listedByMode: Record<AgentHostExternalSessionsMode, string[]> = {
+				[AgentHostExternalSessionsMode.None]: [],
+				[AgentHostExternalSessionsMode.All]: [],
+				[AgentHostExternalSessionsMode.Last24Hours]: [],
+				[AgentHostExternalSessionsMode.Last7Days]: [],
+			};
+			let recentMetadata: IAgentSessionMetadata | undefined;
+			for (const mode of [AgentHostExternalSessionsMode.None, AgentHostExternalSessionsMode.All, AgentHostExternalSessionsMode.Last24Hours, AgentHostExternalSessionsMode.Last7Days]) {
+				setExternalSessionsMode(svc, mode);
+				await waitForExternalReconciliation(svc);
+				const listed = await svc.listSessions();
+				listedByMode[mode] = listed.map(session => AgentSession.id(session.session)).sort();
+				recentMetadata ??= listed.find(session => AgentSession.id(session.session) === 'recent');
+			}
+
+			assert.deepStrictEqual({
+				listedByMode,
+				recentMeta: recentMetadata?._meta,
+				recentRead: !!((recentMetadata?.status ?? 0) & SessionStatus.IsRead),
+			}, {
+				listedByMode: {
+					[AgentHostExternalSessionsMode.None]: ['internal'],
+					[AgentHostExternalSessionsMode.All]: ['at-24-hours', 'at-7-days', 'internal', 'older-than-24-hours', 'older-than-7-days', 'recent'],
+					[AgentHostExternalSessionsMode.Last24Hours]: ['at-24-hours', 'internal', 'recent'],
+					[AgentHostExternalSessionsMode.Last7Days]: ['at-24-hours', 'at-7-days', 'internal', 'older-than-24-hours', 'recent'],
+				},
+				recentMeta: { 'vscode.external': true },
+				recentRead: true,
+			});
+		});
+
+		test('provider and configuration changes reconcile without list calls mutating the broadcast baseline', async () => {
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const notifications: string[] = [];
+			disposables.add(svc.onDidNotification(notification => {
+				if (notification.type === NotificationType.SessionAdded) {
+					notifications.push(`add:${notification.summary.resource}`);
+				} else if (notification.type === NotificationType.SessionRemoved) {
+					notifications.push(`remove:${notification.session}`);
+				}
+			}));
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.None);
+			await waitForExternalReconciliation(svc);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+
+			const hidden = agent.addSession('hidden', now);
+			agent.fireCatalog('hidden');
+			await waitForRegisteredSessions(svc, 1);
+			await waitForExternalReconciliation(svc);
+			assert.deepStrictEqual({
+				listed: await svc.listSessions(),
+				notifications,
+				registered: (await (svc as unknown as { _sessionRegistry: AgentSessionRegistry })._sessionRegistry.list()).map(entry => ({
+					session: entry.session.toString(),
+					provider: entry.provider,
+					startTime: entry.startTime,
+					external: entry.external,
+					source: entry.source,
+				})),
+			}, {
+				listed: [],
+				notifications: [],
+				registered: [{ session: hidden.toString(), provider: 'copilot', startTime: now, external: true, source: 'discovery' }],
+			});
+
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.All);
+			await waitForExternalReconciliation(svc);
+			notifications.length = 0;
+
+			const racing = agent.addSession('racing', now);
+			agent.fireCatalog('racing');
+			await svc.listSessions();
+			await waitForRegisteredSessions(svc, 2);
+			await waitForExternalReconciliation(svc);
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.None);
+			await waitForExternalReconciliation(svc);
+
+			assert.deepStrictEqual(notifications, [
+				`add:${racing.toString()}`,
+				`remove:${hidden.toString()}`,
+				`remove:${racing.toString()}`,
+			]);
+		});
+
+		test('reconciles exactly after a visible external session crosses the inclusive cutoff', async () => {
+			const day = 24 * 60 * 60 * 1000;
+			let now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const session = agent.addSession('expiring', now - day + 50);
+			const removed: string[] = [];
+			disposables.add(svc.onDidNotification(notification => {
+				if (notification.type === NotificationType.SessionRemoved) {
+					removed.push(notification.session);
+				}
+			}));
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.Last24Hours);
+			await waitForExternalReconciliation(svc);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			agent.fireCatalog();
+			await waitForRegisteredSessions(svc, 1);
+			await waitForExternalReconciliation(svc);
+
+			now += 50;
+			const atBoundary = (await svc.listSessions()).map(entry => entry.session.toString());
+			now += 1;
+			await timeout(60);
+			await waitForExternalReconciliation(svc);
+
+			assert.deepStrictEqual({
+				atBoundary,
+				afterExpiry: await svc.listSessions(),
+				removed,
+			}, {
+				atBoundary: [session.toString()],
+				afterExpiry: [],
+				removed: [session.toString()],
+			});
+		});
+
+		test('retains a restored external session while hidden and preserves restore metadata', async () => {
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const session = agent.addSession('restored', now);
+			const added: string[] = [];
+			disposables.add(svc.onDidNotification(notification => {
+				if (notification.type === NotificationType.SessionAdded) {
+					added.push(notification.summary.resource);
+				}
+			}));
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.None);
+			await waitForExternalReconciliation(svc);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			agent.fireCatalog();
+			await waitForRegisteredSessions(svc, 1);
+			await waitForExternalReconciliation(svc);
+			await svc.restoreSession(session);
+			await waitForExternalReconciliation(svc);
+			const listed = await svc.listSessions();
+			const state = svc.stateManager.getSessionState(session.toString());
+
+			assert.deepStrictEqual({
+				added,
+				listed: listed.map(entry => entry.session.toString()),
+				listExternal: readSessionExternal(listed[0]?._meta),
+				listRead: !!((listed[0]?.status ?? 0) & SessionStatus.IsRead),
+				stateExternal: readSessionExternal(state?._meta),
+				stateRead: !!((state?.status ?? 0) & SessionStatus.IsRead),
+			}, {
+				added: [session.toString()],
+				listed: [session.toString()],
+				listExternal: true,
+				listRead: true,
+				stateExternal: true,
+				stateRead: true,
+			});
+		});
+
+		test('failed used-state persistence does not reschedule expired sessions', async () => {
+			const day = 24 * 60 * 60 * 1000;
+			let now = Date.now();
+			const database = new TransientRegistryWriteDatabase();
+			const svc = createExternalSessionService(() => now, database);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const session = agent.addSession('failed-use-persistence', now - day);
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.Last24Hours);
+			await waitForExternalReconciliation(svc);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			agent.fireCatalog();
+			await waitForRegisteredSessions(svc, 1);
+			await waitForExternalReconciliation(svc);
+			await svc.restoreSession(session);
+			await waitForExternalReconciliation(svc);
+
+			database.failRegistryWrites(2);
+			svc.dispatchAction(buildDefaultChatUri(session.toString()), {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: new Date(now).toISOString(),
+				message: { text: 'hello', origin: { kind: MessageKind.User } },
+			}, 'failed-use-test', 1);
+			now += 1;
+			await timeout(10);
+			await waitForExternalReconciliation(svc);
+
+			assert.deepStrictEqual({
+				writeAttempts: database.registryWriteAttempts,
+				external: readSessionExternal(svc.stateManager.getSessionState(session.toString())?._meta),
+				expiryAt: (svc as unknown as { _externalSessionExpiryAt: number | undefined })._externalSessionExpiryAt,
+			}, {
+				writeAttempts: 2,
+				external: true,
+				expiryAt: undefined,
+			});
+		});
+
+		test('first accepted turn resumes unread behavior and persists used state without blocking dispatch', async () => {
+			const now = Date.now();
+			const database = new TransientRegistryWriteDatabase();
+			const svc = createExternalSessionService(() => now, database);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const session = agent.addSession('used', now);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			agent.fireCatalog();
+			await waitForRegisteredSessions(svc, 1);
+			await waitForExternalReconciliation(svc);
+			await svc.restoreSession(session);
+			const before = (await svc.listSessions())[0];
+
+			database.failRegistryWrites(1);
+			const writeGate = database.pauseRegistryWrites();
+			const chat = buildDefaultChatUri(session.toString());
+			svc.dispatchAction(chat, {
+				type: ActionType.ChatTurnStarted,
+				turnId: 'turn-1',
+				startedAt: new Date(now).toISOString(),
+				message: { text: 'hello', origin: { kind: MessageKind.User } },
+			}, 'external-use-test', 1);
+			await timeout(0);
+			const duringWrite = svc.stateManager.getSessionState(session.toString());
+
+			assert.deepStrictEqual({
+				beforeExternal: readSessionExternal(before._meta),
+				beforeRead: !!((before.status ?? 0) & SessionStatus.IsRead),
+				writeAttempts: database.registryWriteAttempts,
+				messageDispatched: agent.sendMessageCalls.length,
+				duringWriteExternal: readSessionExternal(duringWrite?._meta),
+				duringWriteRead: !!((duringWrite?.status ?? 0) & SessionStatus.IsRead),
+			}, {
+				beforeExternal: true,
+				beforeRead: true,
+				writeAttempts: 2,
+				messageDispatched: 1,
+				duringWriteExternal: true,
+				duringWriteRead: true,
+			});
+
+			writeGate.complete();
+			for (let attempt = 0; attempt < 50 && readSessionExternal(svc.stateManager.getSessionState(session.toString())?._meta); attempt++) {
+				await timeout(0);
+			}
+			agent.fireCatalog('used');
+			await waitForExternalReconciliation(svc);
+			agent.fireProgress({
+				kind: 'action',
+				resource: URI.parse(chat),
+				action: { type: ActionType.ChatTurnComplete, turnId: 'turn-1', duration: 1 },
+			});
+			const after = (await svc.listSessions())[0];
+			const registered = await (svc as unknown as { _sessionRegistry: AgentSessionRegistry })._sessionRegistry.list();
+
+			assert.deepStrictEqual({
+				registered: registered.map(entry => ({ external: entry.external, source: entry.source })),
+				afterExternal: readSessionExternal(after._meta),
+				afterRead: !!((after.status ?? 0) & SessionStatus.IsRead),
+			}, {
+				registered: [{ external: false, source: 'explicit' }],
+				afterExternal: false,
+				afterRead: false,
+			});
 		});
 
 		test('listSessions discovers provider-native sessions as external and restore preserves provenance', async () => {
@@ -3801,6 +4181,8 @@ suite('AgentService (node dispatcher)', () => {
 
 			const provisionalAgent = new ProvisionalMockAgent('copilot');
 			disposables.add(toDisposable(() => provisionalAgent.dispose()));
+			setExternalSessionsMode(service, AgentHostExternalSessionsMode.None);
+			await waitForExternalReconciliation(service);
 			service.registerProvider(provisionalAgent);
 
 			const session = await service.createSession({ provider: 'copilot' });

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -2663,7 +2663,7 @@ suite('AgentService (node dispatcher)', () => {
 			]);
 		});
 
-		test('reconciles exactly after a visible external session crosses the inclusive cutoff', async () => {
+		test('applies the time window on list without expiry notifications', async () => {
 			const day = 24 * 60 * 60 * 1000;
 			let now = Date.now();
 			const svc = createExternalSessionService(() => now);
@@ -2686,17 +2686,22 @@ suite('AgentService (node dispatcher)', () => {
 			now += 50;
 			const atBoundary = (await svc.listSessions()).map(entry => entry.session.toString());
 			now += 1;
-			await timeout(60);
+			await timeout(20);
+			agent.fireCatalog();
 			await waitForExternalReconciliation(svc);
+			const removedBeforeList = [...removed];
+			const afterExpiry = await svc.listSessions();
 
 			assert.deepStrictEqual({
 				atBoundary,
-				afterExpiry: await svc.listSessions(),
+				afterExpiry,
+				removedBeforeList,
 				removed,
 			}, {
 				atBoundary: [session.toString()],
 				afterExpiry: [],
-				removed: [session.toString()],
+				removedBeforeList: [],
+				removed: [],
 			});
 		});
 
@@ -2737,45 +2742,6 @@ suite('AgentService (node dispatcher)', () => {
 				listRead: true,
 				stateExternal: true,
 				stateRead: true,
-			});
-		});
-
-		test('failed used-state persistence does not reschedule expired sessions', async () => {
-			const day = 24 * 60 * 60 * 1000;
-			let now = Date.now();
-			const database = new TransientRegistryWriteDatabase();
-			const svc = createExternalSessionService(() => now, database);
-			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
-			const session = agent.addSession('failed-use-persistence', now - day);
-			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.Last24Hours);
-			await waitForExternalReconciliation(svc);
-			svc.registerProvider(agent);
-			await svc.listSessions();
-			agent.fireCatalog();
-			await waitForRegisteredSessions(svc, 1);
-			await waitForExternalReconciliation(svc);
-			await svc.restoreSession(session);
-			await waitForExternalReconciliation(svc);
-
-			database.failRegistryWrites(2);
-			svc.dispatchAction(buildDefaultChatUri(session.toString()), {
-				type: ActionType.ChatTurnStarted,
-				turnId: 'turn-1',
-				startedAt: new Date(now).toISOString(),
-				message: { text: 'hello', origin: { kind: MessageKind.User } },
-			}, 'failed-use-test', 1);
-			now += 1;
-			await timeout(10);
-			await waitForExternalReconciliation(svc);
-
-			assert.deepStrictEqual({
-				writeAttempts: database.registryWriteAttempts,
-				external: readSessionExternal(svc.stateManager.getSessionState(session.toString())?._meta),
-				expiryAt: (svc as unknown as { _externalSessionExpiryAt: number | undefined })._externalSessionExpiryAt,
-			}, {
-				writeAttempts: 2,
-				external: true,
-				expiryAt: undefined,
 			});
 		});
 

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -2524,6 +2524,7 @@ suite('AgentService (node dispatcher)', () => {
 				undefined,
 				[],
 				AgentHostLaunchKind.Unknown,
+				undefined,
 				database,
 				now,
 			));

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -2539,8 +2539,15 @@ suite('AgentService (node dispatcher)', () => {
 		}
 
 		async function waitForExternalReconciliation(service: AgentService): Promise<void> {
-			await timeout(0);
-			await (service as unknown as { _externalSessionReconciliation: Promise<void> })._externalSessionReconciliation;
+			const target = service as unknown as { _externalSessionReconciliation: Promise<void> };
+			while (true) {
+				const reconciliation = target._externalSessionReconciliation;
+				await reconciliation;
+				await timeout(0);
+				if (reconciliation === target._externalSessionReconciliation) {
+					return;
+				}
+			}
 		}
 
 		async function waitForRegisteredSessions(service: AgentService, count: number): Promise<void> {
@@ -2647,6 +2654,10 @@ suite('AgentService (node dispatcher)', () => {
 			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.All);
 			await waitForExternalReconciliation(svc);
 			notifications.length = 0;
+			const baseline = svc as unknown as { _broadcastExternalSessions: Map<string, IAgentSessionMetadata> };
+			const baselineBeforeList = [...baseline._broadcastExternalSessions.keys()];
+			await svc.listSessions();
+			const baselineAfterList = [...baseline._broadcastExternalSessions.keys()];
 
 			const racing = agent.addSession('racing', now);
 			agent.fireCatalog('racing');
@@ -2656,11 +2667,131 @@ suite('AgentService (node dispatcher)', () => {
 			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.None);
 			await waitForExternalReconciliation(svc);
 
-			assert.deepStrictEqual(notifications, [
-				`add:${racing.toString()}`,
-				`remove:${hidden.toString()}`,
-				`remove:${racing.toString()}`,
-			]);
+			assert.deepStrictEqual({
+				baselineBeforeList,
+				baselineAfterList,
+				notifications,
+			}, {
+				baselineBeforeList: [hidden.toString()],
+				baselineAfterList: [hidden.toString()],
+				notifications: [
+					`add:${racing.toString()}`,
+					`remove:${hidden.toString()}`,
+					`remove:${racing.toString()}`,
+				],
+			});
+		});
+
+		test('narrowing the window retracts only sessions outside the new window', async () => {
+			const day = 24 * 60 * 60 * 1000;
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const recent = agent.addSession('recent-window', now);
+			const old = agent.addSession('old-window', now - 2 * day);
+			const notifications: string[] = [];
+			disposables.add(svc.onDidNotification(notification => {
+				if (notification.type === NotificationType.SessionAdded) {
+					notifications.push(`add:${notification.summary.resource}`);
+				} else if (notification.type === NotificationType.SessionRemoved) {
+					notifications.push(`remove:${notification.session}`);
+				}
+			}));
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.All);
+			await waitForExternalReconciliation(svc);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			agent.fireCatalog();
+			await waitForRegisteredSessions(svc, 2);
+			await waitForExternalReconciliation(svc);
+			notifications.length = 0;
+
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.Last24Hours);
+			await waitForExternalReconciliation(svc);
+
+			assert.deepStrictEqual({
+				listed: (await svc.listSessions()).map(session => session.session.toString()).sort(),
+				notifications,
+			}, {
+				listed: [recent.toString()],
+				notifications: [`remove:${old.toString()}`],
+			});
+		});
+
+		test('reconciliation uses fresh provider metadata after discovery', async () => {
+			const day = 24 * 60 * 60 * 1000;
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new ExternalCatalogAgent('copilot'));
+			const session = agent.addSession('refreshed-metadata', now - 2 * day);
+			const removed: string[] = [];
+			disposables.add(svc.onDidNotification(notification => {
+				if (notification.type === NotificationType.SessionRemoved) {
+					removed.push(notification.session);
+				}
+			}));
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.All);
+			await waitForExternalReconciliation(svc);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			agent.fireCatalog();
+			await waitForRegisteredSessions(svc, 1);
+			await waitForExternalReconciliation(svc);
+
+			agent.addSession('refreshed-metadata', now);
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.Last24Hours);
+			await waitForExternalReconciliation(svc);
+
+			assert.deepStrictEqual({
+				listed: (await svc.listSessions()).map(entry => entry.session.toString()),
+				removed,
+			}, {
+				listed: [session.toString()],
+				removed: [],
+			});
+		});
+
+		test('metadata failures during a mode change retain the broadcast session', async () => {
+			class FailingMetadataAgent extends ExternalCatalogAgent {
+				failMetadata = false;
+
+				override async getChatMetadata(chat: URI, context: URI | IAgentChatContext): Promise<IAgentChatMetadata | undefined> {
+					if (this.failMetadata) {
+						throw new Error('metadata unavailable');
+					}
+					return super.getChatMetadata(chat, context);
+				}
+			}
+
+			const now = Date.now();
+			const svc = createExternalSessionService(() => now);
+			const agent = disposables.add(new FailingMetadataAgent('copilot'));
+			const session = agent.addSession('metadata-failure', now);
+			const removed: string[] = [];
+			disposables.add(svc.onDidNotification(notification => {
+				if (notification.type === NotificationType.SessionRemoved) {
+					removed.push(notification.session);
+				}
+			}));
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.All);
+			await waitForExternalReconciliation(svc);
+			svc.registerProvider(agent);
+			await svc.listSessions();
+			agent.fireCatalog();
+			await waitForRegisteredSessions(svc, 1);
+			await waitForExternalReconciliation(svc);
+			agent.failMetadata = true;
+
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.Last24Hours);
+			await waitForExternalReconciliation(svc);
+
+			assert.deepStrictEqual({
+				baseline: [...(svc as unknown as { _broadcastExternalSessions: Map<string, IAgentSessionMetadata> })._broadcastExternalSessions.keys()],
+				removed,
+			}, {
+				baseline: [session.toString()],
+				removed: [],
+			});
 		});
 
 		test('applies the time window on list without expiry notifications', async () => {
@@ -2800,15 +2931,20 @@ suite('AgentService (node dispatcher)', () => {
 			});
 			const after = (await svc.listSessions())[0];
 			const registered = await (svc as unknown as { _sessionRegistry: AgentSessionRegistry })._sessionRegistry.list();
+			setExternalSessionsMode(svc, AgentHostExternalSessionsMode.None);
+			await waitForExternalReconciliation(svc);
+			const afterNone = await svc.listSessions();
 
 			assert.deepStrictEqual({
 				registered: registered.map(entry => ({ external: entry.external, source: entry.source })),
 				afterExternal: readSessionExternal(after._meta),
 				afterRead: !!((after.status ?? 0) & SessionStatus.IsRead),
+				afterNone: afterNone.map(entry => entry.session.toString()),
 			}, {
 				registered: [{ external: false, source: 'explicit' }],
 				afterExternal: false,
 				afterRead: false,
+				afterNone: [session.toString()],
 			});
 		});
 
@@ -4148,8 +4284,6 @@ suite('AgentService (node dispatcher)', () => {
 
 			const provisionalAgent = new ProvisionalMockAgent('copilot');
 			disposables.add(toDisposable(() => provisionalAgent.dispose()));
-			setExternalSessionsMode(service, AgentHostExternalSessionsMode.None);
-			await waitForExternalReconciliation(service);
 			service.registerProvider(provisionalAgent);
 
 			const session = await service.createSession({ provider: 'copilot' });

--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -14,7 +14,7 @@ import '../../../../platform/agentHost/browser/agentHostEnablementService.js';
 import '../../../../platform/agentHost/common/agentHostStarter.config.contribution.js';
 import { AgentHostAhpJsonlLoggingSettingId, AgentHostAllowSignedOutWhenUsableSettingId, AgentHostSdkSandboxEnabledSettingId, AgentHostSdkSandboxWindowsEnabledSettingId, CodexPreferAgentHostEditorSettingId } from '../../../../platform/agentHost/common/agentService.js';
 import { AgentHostCopilotModelCapabilityOverridesSettingId, AgentHostCopilotSdkLogLevelSettingId, AgentHostCustomTerminalToolEnabledSettingId, AgentHostOpus48PromptEnabledSettingId, AgentHostToolSearchDeferThresholdSettingId, AgentHostToolSearchEnabledSettingId, copilotSdkLogLevelSettingValues } from '../../../../platform/agentHost/common/copilotCliConfig.js';
-import { AgentHostAutoReplyEnabledConfigKey, AgentHostEditAutoApprovePatternsConfigKey, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey } from '../../../../platform/agentHost/common/agentHostSchema.js';
+import { AgentHostAutoReplyEnabledConfigKey, AgentHostEditAutoApprovePatternsConfigKey, AgentHostExternalSessionsMode, AgentHostGlobalAutoApproveEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostShowExternalSessionsConfigKey } from '../../../../platform/agentHost/common/agentHostSchema.js';
 import { AgentHostMapLegacySettingsToManagedSettingsSettingId } from '../../../../platform/agentHost/common/agentHostManagedSettings.js';
 import { DEFAULT_EDIT_AUTO_APPROVE_PATTERNS, mergeChatEditAutoApprovePatterns } from '../../../../platform/chat/common/chatSettings.js';
 import { reasoningEffortLevels } from '../../../../platform/agentHost/common/reasoningEffort.js';
@@ -394,6 +394,19 @@ configurationRegistry.registerConfiguration({
 				mode: 'startup'
 			},
 			agentHost: { key: AgentHostMigrateLegacyCopilotCliEnabledConfigKey },
+		},
+		[ChatConfiguration.ShowExternalAgentSessions]: {
+			type: 'string',
+			enum: [AgentHostExternalSessionsMode.None, AgentHostExternalSessionsMode.All, AgentHostExternalSessionsMode.Last24Hours, AgentHostExternalSessionsMode.Last7Days],
+			enumDescriptions: [
+				nls.localize('chat.agentSessions.showExternal.none', "Only shows sessions created or used by the Agent Host."),
+				nls.localize('chat.agentSessions.showExternal.all', "Shows all sessions discovered from supported external agent applications."),
+				nls.localize('chat.agentSessions.showExternal.last24Hours', "Shows external sessions updated in the last 24 hours."),
+				nls.localize('chat.agentSessions.showExternal.last7Days', "Shows external sessions updated in the last 7 days."),
+			],
+			default: AgentHostExternalSessionsMode.Last7Days,
+			markdownDescription: nls.localize('chat.agentSessions.showExternal', "Controls which external agent sessions, created outside VS Code's Agent Host, are shown."),
+			agentHost: { key: AgentHostShowExternalSessionsConfigKey },
 		},
 		[ChatConfiguration.SaveBeforeSend]: {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/chat/common/constants.ts
+++ b/src/vs/workbench/contrib/chat/common/constants.ts
@@ -47,6 +47,7 @@ export enum ChatConfiguration {
 	UnifiedAgentsBar = 'chat.unifiedAgentsBar.enabled',
 	AgentSessionProjectionEnabled = 'chat.agentSessionProjection.enabled',
 	MigrateLegacyCopilotCliSessions = 'chat.agentSessions.migrateLegacyCopilotCli',
+	ShowExternalAgentSessions = 'chat.agentSessions.showExternal',
 	ExtensionToolsEnabled = 'chat.extensionTools.enabled',
 	RepoInfoEnabled = 'chat.repoInfo.enabled',
 	EditRequests = 'chat.editRequests',


### PR DESCRIPTION
## Summary

- adds the user setting `chat.agentSessions.showExternal` with `none`, `all`, `last24Hours`, and `last7Days` modes (default: `last7Days`), synchronized globally through Agent Host root configuration
- centralizes external-session exposure in `AgentService`, including immediate multi-client add/remove reconciliation, an isolated broadcast baseline, inclusive time-window filtering on list requests, and live/provisional retention
- keeps provider-native discovery and durable registration unchanged while preserving typed `vscode.external` metadata through listing, surfacing, and restore
- forces unused external sessions read; after the first accepted Agent Host turn, source-aware explicit registration transitions the durable entry without delaying dispatch, with retry and logging

Time windows are evaluated when sessions are listed. Agent Host does not schedule expiry timers or broadcast removals merely because a 24-hour or 7-day boundary elapsed.

## Dependency

Builds on #330665 (`agentHost: discover provider-native chats`) and intentionally reuses its database, provenance, provider discovery, and `_meta` architecture. #330665 merged while this PR was being prepared, so this branch was rebased onto `main` before opening.

## Validation

- `npm run transpile-client`
- `npm run eslint -- <changed TypeScript files>`
- `scripts/test.bat --run src/vs/platform/agentHost/test/node/agentService.test.ts --run src/vs/platform/agentHost/test/node/agentHostStateManager.test.ts` (368 passing, 17 pending)
- `scripts/test.bat --run src/vs/platform/agentHost/test/common/agentHostConfigurationSync.test.ts` (10 passing)
- `npm run typecheck-client` (only existing unrelated errors in `copilotSessionLauncher` managed-settings types and `assignmentService` callback parameter types)