### PR TITLE
Revert to showing all context size options

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -3362,11 +3362,6 @@
             "default": true,
             "description": "%github.copilot.config.agent.currentEditorContext.enabled%"
           },
-          "github.copilot.chat.preferLongContext.enabled": {
-            "type": "boolean",
-            "default": true,
-            "markdownDescription": "%github.copilot.config.preferLongContext.enabled%"
-          },
           "github.copilot.enable": {
             "type": "object",
             "scope": "window",

--- a/extensions/copilot/package.nls.json
+++ b/extensions/copilot/package.nls.json
@@ -327,7 +327,6 @@
 	"copilot.tools.createDirectory.name": "Create Directory",
 	"copilot.tools.createDirectory.description": "Create new directories in your workspace",
 	"github.copilot.config.agent.currentEditorContext.enabled": "When enabled, Copilot will include the name of the current active editor in the context for agent mode.",
-	"github.copilot.config.preferLongContext.enabled": "When enabled, models that offer their full (long) context window at no additional cost will only show the long context option in the model picker and use it by default. When disabled, both the smaller default and larger long context options are shown so you can select a smaller context window.",
 	"github.copilot.config.customInstructionsInSystemMessage": "When enabled, custom instructions and mode instructions will be appended to the system message instead of a user message.",
 	"github.copilot.config.organizationCustomAgents.enabled": "When enabled, Copilot will load custom agents defined by your GitHub Organization.",
 	"github.copilot.config.organizationInstructions.enabled": "When enabled, Copilot will load custom instructions defined by your GitHub Organization.",

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
@@ -227,7 +227,6 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 	private _buildModelInfos(models: CopilotCLIModelInfo[]): vscode.LanguageModelChatInformation[] {
 		const isReasoningEffortEnabled = this.configurationService.getConfig(ConfigKey.Advanced.CLIThinkingEffortEnabled);
 		const isAutoModelEnabled = this.configurationService.getConfig(ConfigKey.Advanced.CLIAutoModelEnabled);
-		const preferLongContext = this.configurationService.getConfig(ConfigKey.PreferLongContext);
 		const modelsInfo: vscode.LanguageModelChatInformation[] = models.map((model, index) => {
 			const multiplier = model.multiplier === undefined ? undefined : `${model.multiplier}x`;
 			const modelInfo: vscode.LanguageModelChatInformation = {
@@ -249,7 +248,7 @@ export class CopilotCLIModels extends Disposable implements ICopilotCLIModels {
 				longContextCacheWriteCost: model.longContextCacheWriteCost,
 				multiplierNumeric: model.multiplier,
 				isUserSelectable: true,
-				...buildConfigurationSchema(model, isReasoningEffortEnabled, preferLongContext),
+				...buildConfigurationSchema(model, isReasoningEffortEnabled),
 				capabilities: {
 					imageInput: model.supportsVision,
 					toolCalling: true
@@ -292,7 +291,7 @@ function buildAutoModel(defaultModel?: CopilotCLIModelInfo): vscode.LanguageMode
 
 export const COPILOT_CLI_CONTEXT_SIZE_PROPERTY = 'contextSize';
 
-function buildConfigurationSchema(modelInfo: CopilotCLIModelInfo, isReasoningEffortEnabled: boolean, preferLongContext: boolean): { configurationSchema?: vscode.LanguageModelConfigurationSchema } {
+function buildConfigurationSchema(modelInfo: CopilotCLIModelInfo, isReasoningEffortEnabled: boolean): { configurationSchema?: vscode.LanguageModelConfigurationSchema } {
 	const properties: Record<string, NonNullable<vscode.LanguageModelConfigurationSchema['properties']>[string]> = {};
 
 	// Reasoning effort config
@@ -319,35 +318,18 @@ function buildConfigurationSchema(modelInfo: CopilotCLIModelInfo, isReasoningEff
 	const defaultContextMax = modelInfo.defaultContextMax;
 	const fullMax = modelInfo.maxInputTokens ?? modelInfo.maxContextWindowTokens;
 	if (defaultContextMax && defaultContextMax < fullMax) {
-		const hasLongContextSurcharge = modelInfo.longContextInputCost !== undefined
-			|| modelInfo.longContextOutputCost !== undefined;
-		if (hasLongContextSurcharge || !preferLongContext) {
-			properties[COPILOT_CLI_CONTEXT_SIZE_PROPERTY] = {
-				type: 'number',
-				title: l10n.t('Context Size'),
-				enum: [defaultContextMax, fullMax],
-				enumItemLabels: [formatTokenCount(defaultContextMax), formatTokenCount(fullMax)],
-				enumDescriptions: [
-					l10n.t('Default'),
-					l10n.t('Longer sessions'),
-				],
-				default: defaultContextMax,
-				group: 'tokens',
-			};
-		} else {
-			// No surcharge and the user prefers long context — show only the long context option as a non-switchable indicator. See microsoft/vscode#322950, microsoft/vscode#323116.
-			properties[COPILOT_CLI_CONTEXT_SIZE_PROPERTY] = {
-				type: 'number',
-				title: l10n.t('Context Size'),
-				enum: [fullMax],
-				enumItemLabels: [formatTokenCount(fullMax)],
-				enumDescriptions: [
-					l10n.t('Longer sessions'),
-				],
-				default: fullMax,
-				group: 'tokens',
-			};
-		}
+		properties[COPILOT_CLI_CONTEXT_SIZE_PROPERTY] = {
+			type: 'number',
+			title: l10n.t('Context Size'),
+			enum: [defaultContextMax, fullMax],
+			enumItemLabels: [formatTokenCount(defaultContextMax), formatTokenCount(fullMax)],
+			enumDescriptions: [
+				l10n.t('Default'),
+				l10n.t('Longer sessions'),
+			],
+			default: defaultContextMax,
+			group: 'tokens',
+		};
 	}
 
 	if (Object.keys(properties).length === 0) {

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
@@ -318,9 +318,7 @@ function buildConfigurationSchema(modelInfo: CopilotCLIModelInfo, isReasoningEff
 	const defaultContextMax = modelInfo.defaultContextMax;
 	const fullMax = modelInfo.maxInputTokens ?? modelInfo.maxContextWindowTokens;
 	if (defaultContextMax && defaultContextMax < fullMax) {
-		// Both options are always offered so the smaller window stays selectable. When the long
-		// context tier has no surcharge, default to the full window (free long context); otherwise
-		// default to the smaller tier so users opt into the surcharge. See microsoft/vscode#322950, microsoft/vscode#323116.
+		// Offer both sizes; default to the full window when long context is free, else the smaller tier.
 		const hasLongContextSurcharge = modelInfo.longContextInputCost !== undefined
 			|| modelInfo.longContextOutputCost !== undefined;
 		properties[COPILOT_CLI_CONTEXT_SIZE_PROPERTY] = {
@@ -708,18 +706,15 @@ export function isEnabledForCopilotCLI(customization: { sessionTypes?: readonly 
 
 /**
  * Maps a user-selected numeric context size to the SDK's context tier.
- * Returns `'long_context'` when the selected size exceeds the default context
- * max, `'default'` when it is within the default tier. When no context size was
- * provided, defaults to `'long_context'` for free long-context models (larger
- * window, no surcharge) and otherwise `undefined` (SDK default tier).
+ * With an explicit selection, `'long_context'` when it exceeds the default max, else `'default'`.
+ * With no selection, `'long_context'` for free long-context models (larger window, no surcharge), else `undefined`.
  */
 export function resolveContextTier(contextSize: unknown, modelInfo: CopilotCLIModelInfo | undefined): 'default' | 'long_context' | undefined {
 	if (!modelInfo?.defaultContextMax) {
 		return undefined;
 	}
 	if (typeof contextSize !== 'number') {
-		// No explicit selection: default free long-context models (larger window, no
-		// surcharge) to the full window; leave surcharged models on the SDK default tier.
+		// No selection: free long context uses the full window; surcharged models stay on the SDK default tier.
 		const fullMax = modelInfo.maxInputTokens ?? modelInfo.maxContextWindowTokens;
 		const hasLongContextSurcharge = modelInfo.longContextInputCost !== undefined
 			|| modelInfo.longContextOutputCost !== undefined;

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/copilotCli.ts
@@ -318,6 +318,11 @@ function buildConfigurationSchema(modelInfo: CopilotCLIModelInfo, isReasoningEff
 	const defaultContextMax = modelInfo.defaultContextMax;
 	const fullMax = modelInfo.maxInputTokens ?? modelInfo.maxContextWindowTokens;
 	if (defaultContextMax && defaultContextMax < fullMax) {
+		// Both options are always offered so the smaller window stays selectable. When the long
+		// context tier has no surcharge, default to the full window (free long context); otherwise
+		// default to the smaller tier so users opt into the surcharge. See microsoft/vscode#322950, microsoft/vscode#323116.
+		const hasLongContextSurcharge = modelInfo.longContextInputCost !== undefined
+			|| modelInfo.longContextOutputCost !== undefined;
 		properties[COPILOT_CLI_CONTEXT_SIZE_PROPERTY] = {
 			type: 'number',
 			title: l10n.t('Context Size'),
@@ -327,7 +332,7 @@ function buildConfigurationSchema(modelInfo: CopilotCLIModelInfo, isReasoningEff
 				l10n.t('Default'),
 				l10n.t('Longer sessions'),
 			],
-			default: defaultContextMax,
+			default: hasLongContextSurcharge ? defaultContextMax : fullMax,
 			group: 'tokens',
 		};
 	}
@@ -704,12 +709,21 @@ export function isEnabledForCopilotCLI(customization: { sessionTypes?: readonly 
 /**
  * Maps a user-selected numeric context size to the SDK's context tier.
  * Returns `'long_context'` when the selected size exceeds the default context
- * max, `'default'` when it is within the default tier, or `undefined` when
- * no context size was provided or the model has no tiered pricing.
+ * max, `'default'` when it is within the default tier. When no context size was
+ * provided, defaults to `'long_context'` for free long-context models (larger
+ * window, no surcharge) and otherwise `undefined` (SDK default tier).
  */
 export function resolveContextTier(contextSize: unknown, modelInfo: CopilotCLIModelInfo | undefined): 'default' | 'long_context' | undefined {
-	if (typeof contextSize !== 'number' || !modelInfo?.defaultContextMax) {
+	if (!modelInfo?.defaultContextMax) {
 		return undefined;
+	}
+	if (typeof contextSize !== 'number') {
+		// No explicit selection: default free long-context models (larger window, no
+		// surcharge) to the full window; leave surcharged models on the SDK default tier.
+		const fullMax = modelInfo.maxInputTokens ?? modelInfo.maxContextWindowTokens;
+		const hasLongContextSurcharge = modelInfo.longContextInputCost !== undefined
+			|| modelInfo.longContextOutputCost !== undefined;
+		return modelInfo.defaultContextMax < fullMax && !hasLongContextSurcharge ? 'long_context' : undefined;
 	}
 	return contextSize > modelInfo.defaultContextMax ? 'long_context' : 'default';
 }

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
@@ -543,6 +543,58 @@ describe('CopilotCLIModels', () => {
 		});
 	});
 
+	describe('context size options', () => {
+		function createLmMock() {
+			let capturedProvider: any;
+			return {
+				mock: {
+					registerLanguageModelChatProvider: (_id: string, provider: any) => {
+						capturedProvider = provider;
+						return { dispose: () => { } };
+					}
+				},
+				getProvider: () => capturedProvider,
+			};
+		}
+
+		it('exposes both context sizes with the smaller as default for a free long-context model', async () => {
+			// Default tier caps context at 200K while the full window is 1M, and there
+			// is no long-context surcharge, so the picker must offer both sizes.
+			const sdk = {
+				_serviceBrand: undefined,
+				getPackage: vi.fn(async () => ({
+					getAvailableModels: vi.fn(async () => [{
+						id: 'free-long-context',
+						name: 'Free Long Context',
+						billing: { token_prices: { default: { input_price: 1, output_price: 1, max_prompt_tokens: 200_000 } } },
+						capabilities: {
+							limits: { max_prompt_tokens: 1_000_000, max_output_tokens: 8_000, max_context_window_tokens: 1_000_000 },
+							supports: { vision: false },
+						},
+					}]),
+				})),
+				getAuthInfo: vi.fn(async () => ({ type: 'token' as const, token: 'test-token', host: 'https://github.com' })),
+				getRequestId: vi.fn(() => undefined),
+				setRequestId: vi.fn(),
+			} as unknown as ICopilotCLISDK;
+
+			const configService = new MockConfigurationService();
+			await configService.setConfig(ConfigKey.Advanced.CLIAutoModelEnabled, false);
+			const { models } = createModels({ hasSession: true, sdk, configService });
+			const lm = createLmMock();
+			models.registerLanguageModelChatProvider(lm.mock as any);
+
+			await models.getModels();
+			await new Promise(r => setTimeout(r, 0));
+
+			const result = await lm.getProvider().provideLanguageModelChatInformation({}, undefined);
+			const model = result.find((m: any) => m.id === 'free-long-context');
+			const contextSize = model?.configurationSchema?.properties?.contextSize;
+			expect(contextSize?.enum).toEqual([200_000, 1_000_000]);
+			expect(contextSize?.default).toBe(200_000);
+		});
+	});
+
 	describe('CLIAutoModelEnabled setting', () => {
 		function createLmMock() {
 			let capturedProvider: any;

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
@@ -557,7 +557,7 @@ describe('CopilotCLIModels', () => {
 			};
 		}
 
-		it('exposes both context sizes with the smaller as default for a free long-context model', async () => {
+		it('exposes both context sizes with the longer as default for a free long-context model', async () => {
 			// Default tier caps context at 200K while the full window is 1M, and there
 			// is no long-context surcharge, so the picker must offer both sizes.
 			const sdk = {
@@ -591,7 +591,7 @@ describe('CopilotCLIModels', () => {
 			const model = result.find((m: any) => m.id === 'free-long-context');
 			const contextSize = model?.configurationSchema?.properties?.contextSize;
 			expect(contextSize?.enum).toEqual([200_000, 1_000_000]);
-			expect(contextSize?.default).toBe(200_000);
+			expect(contextSize?.default).toBe(1_000_000);
 		});
 	});
 

--- a/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
+++ b/extensions/copilot/src/extension/chatSessions/copilotcli/node/test/copilotCliModels.spec.ts
@@ -558,8 +558,7 @@ describe('CopilotCLIModels', () => {
 		}
 
 		it('exposes both context sizes with the longer as default for a free long-context model', async () => {
-			// Default tier caps context at 200K while the full window is 1M, and there
-			// is no long-context surcharge, so the picker must offer both sizes.
+			// Free long context: default tier 200K, full window 1M, no surcharge — picker offers both.
 			const sdk = {
 				_serviceBrand: undefined,
 				getPackage: vi.fn(async () => ({

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -10,7 +10,6 @@ import { IAuthenticationService } from '../../../platform/authentication/common/
 import { CopilotToken } from '../../../platform/authentication/common/copilotToken';
 import { IBlockedExtensionService } from '../../../platform/chat/common/blockedExtensionService';
 import { ChatFetchResponseType, ChatLocation, getErrorDetailsFromChatFetchError } from '../../../platform/chat/common/commonTypes';
-import { ConfigKey, IConfigurationService } from '../../../platform/configuration/common/configurationService';
 import { getTextPart } from '../../../platform/chat/common/globalStringUtils';
 import { EmbeddingType, getWellKnownEmbeddingTypeInfo, IEmbeddingsComputer } from '../../../platform/embeddings/common/embeddingsComputer';
 import { AUTO_MODE_TIER_PROPERTY, defaultAutoModeTier, selectableAutoModeTiers } from '../../../platform/endpoint/common/autoModeTiers';
@@ -57,7 +56,7 @@ const experimentalAutoModelHintMarkers = ['minimax', 'mp3yn0h7', 'yaqq2gxh'];
  * Builds a configurationSchema for the model picker based on the endpoint's supported capabilities.
  * Models that support reasoning_effort get a "Thinking Effort" dropdown in the model picker UI.
  */
-function getContextSizeOptions(endpoint: IChatEndpoint, preferLongContext: boolean): { value: number; description: string; isDefault: boolean }[] | undefined {
+function getContextSizeOptions(endpoint: IChatEndpoint): { value: number; description: string; isDefault: boolean }[] | undefined {
 	const pricing = endpoint.tokenPricing;
 
 	// Only offer a selector when CAPI provides a default context max,
@@ -72,15 +71,6 @@ function getContextSizeOptions(endpoint: IChatEndpoint, preferLongContext: boole
 	// No point showing a selector if the default is already the full context
 	if (defaultMax >= fullMax) {
 		return undefined;
-	}
-
-	const hasLongContextSurcharge = !!pricing.longContext;
-
-	// When both tiers cost the same and the user prefers long context, show only the full window as a non-switchable indicator. See microsoft/vscode#322950, microsoft/vscode#323116.
-	if (preferLongContext && !hasLongContextSurcharge) {
-		return [
-			{ value: fullMax, description: vscode.l10n.t('Longer sessions'), isDefault: true },
-		];
 	}
 
 	return [
@@ -131,7 +121,7 @@ function buildAutoRoutingContext(
 
 // Auto model delegates to different backends, so the only picker it exposes is
 // the routing tier; per-model options belong to the model it routes to.
-function buildConfigurationSchema(endpoint: IChatEndpoint, preferLongContext: boolean, autoTiersEnabled: boolean): { configurationSchema?: vscode.LanguageModelConfigurationSchema } {
+function buildConfigurationSchema(endpoint: IChatEndpoint, autoTiersEnabled: boolean): { configurationSchema?: vscode.LanguageModelConfigurationSchema } {
 	if (endpoint instanceof AutoChatEndpoint) {
 		return autoTiersEnabled
 			? { configurationSchema: { properties: { [AUTO_MODE_TIER_PROPERTY]: buildAutoModeTierSchemaProperty(selectableAutoModeTiers, defaultAutoModeTier) } } }
@@ -147,7 +137,7 @@ function buildConfigurationSchema(endpoint: IChatEndpoint, preferLongContext: bo
 	}
 
 	// Context size config
-	const contextSizeOptions = getContextSizeOptions(endpoint, preferLongContext);
+	const contextSizeOptions = getContextSizeOptions(endpoint);
 	if (contextSizeOptions) {
 		const defaultOption = contextSizeOptions.find(o => o.isDefault);
 		properties.contextSize = {
@@ -254,7 +244,6 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 		@IVSCodeExtensionContext private readonly _vsCodeExtensionContext: IVSCodeExtensionContext,
 		@IAutomodeService private readonly _automodeService: IAutomodeService,
 		@IExperimentationService private readonly _expService: IExperimentationService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 
@@ -337,7 +326,6 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 		}
 
 		const seenFamilies = new Set<string>();
-		const preferLongContext = this._configurationService.getConfig(ConfigKey.PreferLongContext);
 		const autoTiersEnabled = this._automodeService.areAutoModeTiersSupported();
 
 		for (const endpoint of chatEndpoints) {
@@ -424,7 +412,7 @@ export class LanguageModelAccess extends Disposable implements IExtensionContrib
 					imageInput: endpoint instanceof AutoChatEndpoint ? true : endpoint.supportsVision,
 					toolCalling: endpoint.supportsToolCalls,
 				},
-				...buildConfigurationSchema(endpoint, preferLongContext, autoTiersEnabled),
+				...buildConfigurationSchema(endpoint, autoTiersEnabled),
 			};
 
 			models.push(model);

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -73,9 +73,7 @@ function getContextSizeOptions(endpoint: IChatEndpoint): { value: number; descri
 		return undefined;
 	}
 
-	// Both options are always offered so the smaller window stays selectable. When the long
-	// context tier has no surcharge, default to the full window (free long context); otherwise
-	// default to the smaller tier so users opt into the surcharge. See microsoft/vscode#322950, microsoft/vscode#323116.
+	// Offer both sizes; default to the full window when long context is free, else the smaller tier.
 	const fullIsDefault = !pricing.longContext;
 
 	return [

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -73,12 +73,17 @@ function getContextSizeOptions(endpoint: IChatEndpoint): { value: number; descri
 		return undefined;
 	}
 
+	// Both options are always offered so the smaller window stays selectable. When the long
+	// context tier has no surcharge, default to the full window (free long context); otherwise
+	// default to the smaller tier so users opt into the surcharge. See microsoft/vscode#322950, microsoft/vscode#323116.
+	const fullIsDefault = !pricing.longContext;
+
 	return [
-		{ value: defaultMax, description: vscode.l10n.t('Default recommended context size'), isDefault: true },
+		{ value: defaultMax, description: vscode.l10n.t('Default recommended context size'), isDefault: !fullIsDefault },
 		{
 			value: fullMax,
 			description: vscode.l10n.t('Longer sessions'),
-			isDefault: false,
+			isDefault: fullIsDefault,
 		},
 	];
 }

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
@@ -371,6 +371,71 @@ suite('LanguageModelAccess model info', () => {
 			languageModelAccess.dispose();
 		}
 	});
+
+	test('publishes both context size options with the smaller window as default for a free long-context model', async () => {
+		const endpoint = {
+			model: 'free-long-context',
+			name: 'Free Long Context',
+			family: 'free-long-context',
+			version: '1',
+			modelProvider: 'copilot',
+			modelMaxPromptTokens: 1_000_000,
+			maxOutputTokens: 8_192,
+			multiplier: 1,
+			supportsToolCalls: true,
+			supportsVision: false,
+			supportsPrediction: false,
+			showInModelPicker: false,
+			isFallback: false,
+			tokenizer: TokenizerType.O200K,
+			urlOrRequestMetadata: '',
+			// Default tier caps context at 200K while the full window is 1M, and there
+			// is no long-context surcharge, so the picker must offer both sizes.
+			tokenPricing: { default: { inputPrice: 1, outputPrice: 1, contextMax: 200_000 } },
+		} as unknown as IChatEndpoint;
+		const copilotToken = new CopilotToken(createTestExtendedTokenInfo({ token: 'token', username: 'fake', copilot_plan: 'unknown' }));
+		const testingServiceCollection = createExtensionTestingServices();
+		testingServiceCollection.define(ICopilotTokenManager, {
+			_serviceBrand: undefined,
+			onDidCopilotTokenRefresh: Event.None,
+			getCopilotToken: async () => copilotToken,
+			resetCopilotToken: () => { },
+		} as unknown as ICopilotTokenManager);
+		testingServiceCollection.define(IAutomodeService, {
+			_serviceBrand: undefined,
+			resolveAutoModeEndpoint: async () => endpoint,
+			resolveAutoModePickerEndpoint: async () => endpoint,
+			getAutoPickerMetadata: () => ({ discountRange: { low: 0, high: 0 } }),
+			areAutoModeTiersSupported: () => false,
+			onDidChangeAutoModeTierSupport: Event.None,
+			consumeLastRoutingDecision: () => undefined,
+			invalidateRouterCache: () => { },
+		} as unknown as IAutomodeService);
+		testingServiceCollection.define(IEndpointProvider, {
+			_serviceBrand: undefined,
+			onDidModelsRefresh: Event.None,
+			getAllCompletionModels: async () => [],
+			getAllChatEndpoints: async () => [endpoint],
+			getChatEndpoint: async () => endpoint,
+			getEmbeddingsEndpoint: async () => { throw new Error('Not implemented in test'); },
+		} as unknown as IEndpointProvider);
+		const accessor = testingServiceCollection.createTestingAccessor();
+		const extensionContext = accessor.get(IVSCodeExtensionContext);
+		const baseCountCacheKey = 'lmBaseCount/free-long-context';
+		await extensionContext.globalState.update(baseCountCacheKey, { extensionVersion: accessor.get(IEnvService).getVersion(), baseCount: 0 });
+		const languageModelAccess = accessor.get(IInstantiationService).createInstance(LanguageModelAccess);
+		try {
+			const modelInfo = await raceTimeout((languageModelAccess as unknown as { _provideLanguageModelChatInfo(options: { silent: boolean }, token: vscode.CancellationToken): Promise<vscode.LanguageModelChatInformation[]> })._provideLanguageModelChatInfo({ silent: true }, CancellationToken.None), 2_000);
+			assert.ok(modelInfo, 'provideLanguageModelChatInfo did not resolve');
+			const model = modelInfo.find(m => m.id === 'free-long-context');
+			const contextSize = (model as unknown as { configurationSchema?: { properties?: Record<string, { enum?: unknown[]; default?: unknown }> } } | undefined)?.configurationSchema?.properties?.contextSize;
+			assert.deepStrictEqual(contextSize?.enum, [200_000, 1_000_000]);
+			assert.strictEqual(contextSize?.default, 200_000);
+		} finally {
+			languageModelAccess.dispose();
+			await extensionContext.globalState.update(baseCountCacheKey, undefined);
+		}
+	});
 });
 
 suite('buildUtilityAliasModelInfo', () => {

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
@@ -372,7 +372,7 @@ suite('LanguageModelAccess model info', () => {
 		}
 	});
 
-	test('publishes both context size options with the smaller window as default for a free long-context model', async () => {
+	test('publishes both context size options with the longer window as default for a free long-context model', async () => {
 		const endpoint = {
 			model: 'free-long-context',
 			name: 'Free Long Context',
@@ -430,7 +430,7 @@ suite('LanguageModelAccess model info', () => {
 			const model = modelInfo.find(m => m.id === 'free-long-context');
 			const contextSize = (model as unknown as { configurationSchema?: { properties?: Record<string, { enum?: unknown[]; default?: unknown }> } } | undefined)?.configurationSchema?.properties?.contextSize;
 			assert.deepStrictEqual(contextSize?.enum, [200_000, 1_000_000]);
-			assert.strictEqual(contextSize?.default, 200_000);
+			assert.strictEqual(contextSize?.default, 1_000_000);
 		} finally {
 			languageModelAccess.dispose();
 			await extensionContext.globalState.update(baseCountCacheKey, undefined);

--- a/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/test/languageModelAccess.test.ts
@@ -389,8 +389,7 @@ suite('LanguageModelAccess model info', () => {
 			isFallback: false,
 			tokenizer: TokenizerType.O200K,
 			urlOrRequestMetadata: '',
-			// Default tier caps context at 200K while the full window is 1M, and there
-			// is no long-context surcharge, so the picker must offer both sizes.
+			// Free long context: default tier 200K, full window 1M, no surcharge — picker offers both.
 			tokenPricing: { default: { inputPrice: 1, outputPrice: 1, contextMax: 200_000 } },
 		} as unknown as IChatEndpoint;
 		const copilotToken = new CopilotToken(createTestExtendedTokenInfo({ token: 'token', username: 'fake', copilot_plan: 'unknown' }));

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -97,16 +97,18 @@ function isResponsesCompactionContextManagementEnabled(endpoint: IChatEndpoint, 
  * Only clamps when the selection is strictly smaller than the model window so
  * the full tier ("Longer sessions") stays uncompacted.
  *
- * When no explicit selection is present, falls back to the default context-max tier.
+ * When no explicit selection is present, falls back to the default context-max tier, unless the
+ * long context tier has no surcharge, in which case the full native window is used (free long context).
  *
  * @internal - exported for testing
  */
 export function applyContextSizeOverride(endpoint: IChatEndpoint, request: vscode.ChatRequest): IChatEndpoint {
 	const contextSize = request.modelConfiguration?.contextSize;
-	// Prefer a valid explicit selection; otherwise fall back to the default tier. Guard against non-positive / non-finite selections (0, -1, NaN, Infinity).
+	// Prefer a valid explicit selection; otherwise fall back to the default tier. Guard against non-positive / non-finite selections (0, -1, NaN, Infinity). When the long context tier has no surcharge, skip the fallback and use the full window (free long context). See microsoft/vscode#322950, microsoft/vscode#323116.
+	const hasLongContextSurcharge = !!endpoint.tokenPricing?.longContext;
 	const effectiveSize = (typeof contextSize === 'number' && Number.isFinite(contextSize) && contextSize > 0)
 		? contextSize
-		: endpoint.tokenPricing?.default.contextMax;
+		: hasLongContextSurcharge ? endpoint.tokenPricing?.default.contextMax : undefined;
 	if (typeof effectiveSize === 'number' && effectiveSize > 0 && effectiveSize < endpoint.modelMaxPromptTokens) {
 		return endpoint.cloneWithTokenOverride(effectiveSize);
 	}

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -97,14 +97,13 @@ function isResponsesCompactionContextManagementEnabled(endpoint: IChatEndpoint, 
  * Only clamps when the selection is strictly smaller than the model window so
  * the full tier ("Longer sessions") stays uncompacted.
  *
- * When no explicit selection is present, falls back to the default context-max tier, unless the
- * long context tier has no surcharge, in which case the full native window is used (free long context).
+ * When no explicit selection is present, uses the default tier, or the full window when long context is free (no surcharge).
  *
  * @internal - exported for testing
  */
 export function applyContextSizeOverride(endpoint: IChatEndpoint, request: vscode.ChatRequest): IChatEndpoint {
 	const contextSize = request.modelConfiguration?.contextSize;
-	// Prefer a valid explicit selection; otherwise fall back to the default tier. Guard against non-positive / non-finite selections (0, -1, NaN, Infinity). When the long context tier has no surcharge, skip the fallback and use the full window (free long context). See microsoft/vscode#322950, microsoft/vscode#323116.
+	// Prefer a valid explicit selection (guard 0/-1/NaN/Infinity); else use the default tier, or the full window when long context is free.
 	const hasLongContextSurcharge = !!endpoint.tokenPricing?.longContext;
 	const effectiveSize = (typeof contextSize === 'number' && Number.isFinite(contextSize) && contextSize > 0)
 		? contextSize

--- a/extensions/copilot/src/extension/intents/node/agentIntent.ts
+++ b/extensions/copilot/src/extension/intents/node/agentIntent.ts
@@ -97,18 +97,16 @@ function isResponsesCompactionContextManagementEnabled(endpoint: IChatEndpoint, 
  * Only clamps when the selection is strictly smaller than the model window so
  * the full tier ("Longer sessions") stays uncompacted.
  *
- * When no explicit selection is present, falls back to the default context-max tier, unless the tiers cost the same and `chat.preferLongContext.enabled` is set, in which case the full native window is used.
+ * When no explicit selection is present, falls back to the default context-max tier.
  *
  * @internal - exported for testing
  */
-export function applyContextSizeOverride(endpoint: IChatEndpoint, request: vscode.ChatRequest, preferLongContext: boolean = false): IChatEndpoint {
+export function applyContextSizeOverride(endpoint: IChatEndpoint, request: vscode.ChatRequest): IChatEndpoint {
 	const contextSize = request.modelConfiguration?.contextSize;
-	// Prefer a valid explicit selection; otherwise fall back to the default tier. Guard against non-positive / non-finite selections (0, -1, NaN, Infinity). When tiers cost the same and the user prefers long context, skip the fallback and use the full window. See microsoft/vscode#322950, microsoft/vscode#323116.
-	const hasLongContextSurcharge = !!endpoint.tokenPricing?.longContext;
-	const useDefaultTierFallback = !preferLongContext || hasLongContextSurcharge;
+	// Prefer a valid explicit selection; otherwise fall back to the default tier. Guard against non-positive / non-finite selections (0, -1, NaN, Infinity).
 	const effectiveSize = (typeof contextSize === 'number' && Number.isFinite(contextSize) && contextSize > 0)
 		? contextSize
-		: useDefaultTierFallback ? endpoint.tokenPricing?.default.contextMax : undefined;
+		: endpoint.tokenPricing?.default.contextMax;
 	if (typeof effectiveSize === 'number' && effectiveSize > 0 && effectiveSize < endpoint.modelMaxPromptTokens) {
 		return endpoint.cloneWithTokenOverride(effectiveSize);
 	}
@@ -670,7 +668,7 @@ export class AgentIntentInvocation extends EditCodeIntentInvocation implements I
 		// so the server-managed compaction threshold (Responses API) is keyed to the
 		// selected tier rather than the model's full native window. See
 		// applyContextSizeOverride for the cost rationale.
-		super(intent, location, applyContextSizeOverride(endpoint, request, configurationService.getConfig(ConfigKey.PreferLongContext)), request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, otelService);
+		super(intent, location, applyContextSizeOverride(endpoint, request), request, intentOptions, instantiationService, codeMapperService, envService, promptPathRepresentationService, endpointProvider, workspaceService, toolsService, configurationService, editLogService, commandService, telemetryService, notebookService, otelService);
 	}
 
 	public override getAvailableTools(): Promise<vscode.LanguageModelToolInformation[]> {

--- a/extensions/copilot/src/extension/intents/node/test/contextSizeOverride.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/contextSizeOverride.spec.ts
@@ -60,24 +60,11 @@ describe('applyContextSizeOverride', () => {
 		expect(clonedWith).toEqual([500_000]);
 	});
 
-	test('falls back to the default context-max tier when long context has no surcharge (setting disabled)', () => {
+	test('falls back to the default context-max tier when long context has no surcharge', () => {
 		const { endpoint, clonedWith } = createEndpoint(1_000_000, 200_000);
 		expect(applyContextSizeOverride(endpoint, createRequest(undefined)).modelMaxPromptTokens).toBe(200_000);
 		expect(applyContextSizeOverride(endpoint, createRequest('big')).modelMaxPromptTokens).toBe(200_000);
 		expect(clonedWith).toEqual([200_000, 200_000]);
-	});
-
-	test('does not clamp when long context has no surcharge and the user prefers long context', () => {
-		const { endpoint, clonedWith } = createEndpoint(1_000_000, 200_000);
-		expect(applyContextSizeOverride(endpoint, createRequest(undefined), true)).toBe(endpoint);
-		expect(applyContextSizeOverride(endpoint, createRequest('big'), true)).toBe(endpoint);
-		expect(clonedWith).toEqual([]);
-	});
-
-	test('an explicit selection is still respected when the user prefers long context', () => {
-		const { endpoint, clonedWith } = createEndpoint(1_000_000, 200_000);
-		expect(applyContextSizeOverride(endpoint, createRequest(200_000), true).modelMaxPromptTokens).toBe(200_000);
-		expect(clonedWith).toEqual([200_000]);
 	});
 
 	test('does not clamp when the default tier equals or exceeds the model window', () => {

--- a/extensions/copilot/src/extension/intents/node/test/contextSizeOverride.spec.ts
+++ b/extensions/copilot/src/extension/intents/node/test/contextSizeOverride.spec.ts
@@ -60,11 +60,17 @@ describe('applyContextSizeOverride', () => {
 		expect(clonedWith).toEqual([500_000]);
 	});
 
-	test('falls back to the default context-max tier when long context has no surcharge', () => {
+	test('uses the full window when long context has no surcharge and no selection is present (free long context)', () => {
 		const { endpoint, clonedWith } = createEndpoint(1_000_000, 200_000);
-		expect(applyContextSizeOverride(endpoint, createRequest(undefined)).modelMaxPromptTokens).toBe(200_000);
-		expect(applyContextSizeOverride(endpoint, createRequest('big')).modelMaxPromptTokens).toBe(200_000);
-		expect(clonedWith).toEqual([200_000, 200_000]);
+		expect(applyContextSizeOverride(endpoint, createRequest(undefined))).toBe(endpoint);
+		expect(applyContextSizeOverride(endpoint, createRequest('big'))).toBe(endpoint);
+		expect(clonedWith).toEqual([]);
+	});
+
+	test('an explicit selection is still respected when long context is free', () => {
+		const { endpoint, clonedWith } = createEndpoint(1_000_000, 200_000);
+		expect(applyContextSizeOverride(endpoint, createRequest(200_000)).modelMaxPromptTokens).toBe(200_000);
+		expect(clonedWith).toEqual([200_000]);
 	});
 
 	test('does not clamp when the default tier equals or exceeds the model window', () => {

--- a/extensions/copilot/src/platform/configuration/common/configurationService.ts
+++ b/extensions/copilot/src/platform/configuration/common/configurationService.ts
@@ -1071,7 +1071,6 @@ export namespace ConfigKey {
 	export const SummarizeAgentConversationHistory = defineSetting<boolean>('chat.summarizeAgentConversationHistory.enabled', ConfigType.Simple, true);
 	export const VirtualToolThreshold = defineSetting<number>('chat.virtualTools.threshold', ConfigType.ExperimentBased, HARD_TOOL_LIMIT);
 	export const CurrentEditorAgentContext = defineSetting<boolean>('chat.agent.currentEditorContext.enabled', ConfigType.Simple, true);
-	export const PreferLongContext = defineSetting<boolean>('chat.preferLongContext.enabled', ConfigType.Simple, true);
 	/** BYOK  */
 	export const AutoFixDiagnostics = defineSetting<boolean>('chat.agent.autoFix', ConfigType.ExperimentBased, false);
 	export const NotebookFollowCellExecution = defineSetting<boolean>('chat.notebook.followCellExecution.enabled', ConfigType.Simple, false);

--- a/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
+++ b/src/vs/platform/agentHost/browser/remoteAgentHostProtocolClient.ts
@@ -39,7 +39,7 @@ import { encodeBase64 } from '../../../base/common/buffer.js';
 import { ILoadEstimator, LoadEstimator } from '../../../base/parts/ipc/common/ipc.net.js';
 import { TELEMETRY_CRASH_REPORTER_SETTING_ID, TELEMETRY_OLD_SETTING_ID, TELEMETRY_SETTING_ID } from '../../telemetry/common/telemetry.js';
 import { getTelemetryLevel } from '../../telemetry/common/telemetryUtils.js';
-import { AgentHostTelemetryLevelConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, PREFER_LONG_CONTEXT_SETTING_ID, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
+import { AgentHostTelemetryLevelConfigKey, AgentHostTerminalAutoApproveEnabledConfigKey, AgentHostTerminalAutoApproveRulesConfigKey, AgentHostDisableRepoInfoTelemetryConfigKey, getAgentHostTerminalAutoApproveRulesConfig, TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID, TERMINAL_AUTO_APPROVE_SETTING_ID, TERMINAL_IGNORE_DEFAULT_AUTO_APPROVE_RULES_SETTING_ID, DISABLE_REPO_INFO_TELEMETRY_SETTING_ID, telemetryLevelToAgentHostConfigValue } from '../common/agentHostSchema.js';
 import { getAgentHostConfigurationSyncEntries, resolveAgentHostConfigurationSyncPatch, resolveAgentHostConfigurationSyncValue } from '../common/agentHostConfigurationSync.js';
 import { managedPermissionsConfigurationIds, resolveManagedSettingsPermissions, type IAgentHostManagedSettingsPermissions } from '../common/agentHostManagedSettings.js';
 import { AgentHostClientConnectionKind, toClientConnectionTelemetryMeta } from '../common/agentHostTelemetry.js';
@@ -367,9 +367,6 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 			}
 			if (e.affectsConfiguration(TELEMETRY_SETTING_ID) || e.affectsConfiguration(TELEMETRY_OLD_SETTING_ID) || e.affectsConfiguration(TELEMETRY_CRASH_REPORTER_SETTING_ID)) {
 				this._updateTelemetryLevel();
-			}
-			if (e.affectsConfiguration(PREFER_LONG_CONTEXT_SETTING_ID)) {
-				this._updatePreferLongContextEnabled();
 			}
 			if (e.affectsConfiguration(TERMINAL_AUTO_APPROVE_ENABLED_SETTING_ID)) {
 				this._updateTerminalAutoApproveEnabled();
@@ -775,7 +772,6 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	private _forwardClientConfig(includeManagedSettings = true): void {
 		this._dispatchRootConfig(resolveAgentHostConfigurationSyncPatch(this._configurationService, this._resourceIdentity === LOCAL_AGENT_HOST_RESOURCE_IDENTITY));
 		this._updateTelemetryLevel();
-		this._updatePreferLongContextEnabled();
 		this._updateTerminalAutoApproveEnabled();
 		this._updateTerminalAutoApproveRules();
 		this._updateDisableRepoInfoTelemetry();
@@ -1596,11 +1592,6 @@ export class RemoteAgentHostProtocolClient extends Disposable implements IAgentC
 	private _updateDisableRepoInfoTelemetry(): void {
 		const disabled = this._configurationService.getValue<boolean>(DISABLE_REPO_INFO_TELEMETRY_SETTING_ID) === true;
 		this._dispatchRootConfig({ [AgentHostDisableRepoInfoTelemetryConfigKey]: disabled });
-	}
-
-	private _updatePreferLongContextEnabled(): void {
-		const enabled = this._configurationService.getValue<boolean>(PREFER_LONG_CONTEXT_SETTING_ID) === true;
-		this._dispatchRootConfig({ [AgentHostPreferLongContextEnabledConfigKey]: enabled });
 	}
 
 	private _updateTerminalAutoApproveEnabled(): void {

--- a/src/vs/platform/agentHost/common/agentHostSchema.ts
+++ b/src/vs/platform/agentHost/common/agentHostSchema.ts
@@ -451,12 +451,6 @@ export const AgentHostAutoReplyEnabledConfigKey = 'autoReplyEnabled';
 
 export const AgentHostAutoReplyAnswer = 'The user is not available to answer your question. Choose a pragmatic option best aligned with the context of the request.';
 
-// Root config key forwarded from the renderer when Copilot Chat's `github.copilot.chat.preferLongContext.enabled` setting changes.
-export const AgentHostPreferLongContextEnabledConfigKey = 'preferLongContextEnabled';
-
-// The Copilot Chat setting ID for preferring long context, forwarded into the agent host root config.
-export const PREFER_LONG_CONTEXT_SETTING_ID = 'github.copilot.chat.preferLongContext.enabled';
-
 /** Root config key forwarded from the renderer for automatic OS system proxy discovery. */
 export const AgentHostSystemProxyEnabledConfigKey = 'systemProxyEnabled';
 
@@ -729,12 +723,6 @@ export const platformRootSchema = createSchema({
 		title: localize('agentHost.config.autoReplyEnabled.title', "Auto Reply"),
 		description: localize('agentHost.config.autoReplyEnabled.description', "Whether VS Code's auto-reply setting is enabled. When `true`, `ask_user` questions are auto-answered instead of blocking on the user, mirroring autopilot mode."),
 		default: false,
-	}),
-	[AgentHostPreferLongContextEnabledConfigKey]: schemaProperty<boolean>({
-		type: 'boolean',
-		title: localize('agentHost.config.preferLongContextEnabled.title', "Prefer Long Context"),
-		description: localize('agentHost.config.preferLongContextEnabled.description', "Whether Copilot Chat's prefer-long-context setting is enabled. When `true` (default), models with a free long context window only show the long context option in the picker. When `false`, the smaller default context option stays selectable."),
-		default: true,
 	}),
 	[AgentHostSystemProxyEnabledConfigKey]: schemaProperty<boolean>({
 		type: 'boolean',

--- a/src/vs/platform/agentHost/common/agentModelPricing.ts
+++ b/src/vs/platform/agentHost/common/agentModelPricing.ts
@@ -225,7 +225,7 @@ export interface ICAPIModelBilling {
  * Converts a CAPI model's billing payload into an {@link IAgentModelPricingMeta} `_meta` bag. Long-context costs are
  * only emitted when there is an actual surcharge (at least one long-context price differs from the default tier).
  * When emitting, any missing long-context field falls back to the default-tier value so the hover table renders
- * complete rows.
+ * complete rows. See {@link hasLongContextSurcharge} for the surcharge detection logic.
  *
  * @param billing - The model's billing info, narrowed through {@link ICAPIModelBilling}.
  * @param priceCategory - An optional override for the price category (e.g. from `modelPickerPriceCategory` on the
@@ -262,4 +262,21 @@ export function createPricingMetaFromBilling(billing: ICAPIModelBilling | undefi
 		discountPercent: typeof billing?.discountPercent === 'number' ? billing.discountPercent : undefined,
 		promo: billing?.promo,
 	});
+}
+
+/**
+ * Whether the model's long-context tier has any cost that differs from its default tier.
+ * Used to decide whether the context-size picker should default to the smaller tier
+ * (surcharge → user opts in) or to the full window (free long context → default to it).
+ */
+export function hasLongContextSurcharge(billing: ICAPIModelBilling | undefined): boolean {
+	const tokenPrices = billing?.tokenPrices;
+	const longContext = tokenPrices?.longContext;
+	if (!longContext) {
+		return false;
+	}
+	return (longContext.inputPrice !== undefined && longContext.inputPrice !== tokenPrices?.inputPrice)
+		|| (longContext.outputPrice !== undefined && longContext.outputPrice !== tokenPrices?.outputPrice)
+		|| (longContext.cachePrice !== undefined && longContext.cachePrice !== tokenPrices?.cachePrice)
+		|| (longContext.cacheWritePrice !== undefined && longContext.cacheWritePrice !== tokenPrices?.cacheWritePrice);
 }

--- a/src/vs/platform/agentHost/common/agentModelPricing.ts
+++ b/src/vs/platform/agentHost/common/agentModelPricing.ts
@@ -266,8 +266,7 @@ export function createPricingMetaFromBilling(billing: ICAPIModelBilling | undefi
 
 /**
  * Whether the model's long-context tier has any cost that differs from its default tier.
- * Used to decide whether the context-size picker should default to the smaller tier
- * (surcharge → user opts in) or to the full window (free long context → default to it).
+ * Drives the context-size picker default: smaller tier when surcharged, full window when free.
  */
 export function hasLongContextSurcharge(billing: ICAPIModelBilling | undefined): boolean {
 	const tokenPrices = billing?.tokenPrices;

--- a/src/vs/platform/agentHost/common/agentModelPricing.ts
+++ b/src/vs/platform/agentHost/common/agentModelPricing.ts
@@ -225,7 +225,7 @@ export interface ICAPIModelBilling {
  * Converts a CAPI model's billing payload into an {@link IAgentModelPricingMeta} `_meta` bag. Long-context costs are
  * only emitted when there is an actual surcharge (at least one long-context price differs from the default tier).
  * When emitting, any missing long-context field falls back to the default-tier value so the hover table renders
- * complete rows. See {@link hasLongContextSurcharge} for the surcharge detection logic.
+ * complete rows.
  *
  * @param billing - The model's billing info, narrowed through {@link ICAPIModelBilling}.
  * @param priceCategory - An optional override for the price category (e.g. from `modelPickerPriceCategory` on the
@@ -262,21 +262,4 @@ export function createPricingMetaFromBilling(billing: ICAPIModelBilling | undefi
 		discountPercent: typeof billing?.discountPercent === 'number' ? billing.discountPercent : undefined,
 		promo: billing?.promo,
 	});
-}
-
-/**
- * Whether the model's long-context tier has any cost that differs from its default tier.
- * Used to decide whether to show a context-size picker (surcharge → user opts in) or to
- * silently use the full context window for free.
- */
-export function hasLongContextSurcharge(billing: ICAPIModelBilling | undefined): boolean {
-	const tokenPrices = billing?.tokenPrices;
-	const longContext = tokenPrices?.longContext;
-	if (!longContext) {
-		return false;
-	}
-	return (longContext.inputPrice !== undefined && longContext.inputPrice !== tokenPrices?.inputPrice)
-		|| (longContext.outputPrice !== undefined && longContext.outputPrice !== tokenPrices?.outputPrice)
-		|| (longContext.cachePrice !== undefined && longContext.cachePrice !== tokenPrices?.cachePrice)
-		|| (longContext.cacheWritePrice !== undefined && longContext.cacheWritePrice !== tokenPrices?.cacheWritePrice);
 }

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1849,9 +1849,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			return undefined;
 		}
 
-		// Both options are always offered so the smaller window stays selectable. When the long
-		// context tier has no surcharge, default to the full window (free long context); otherwise
-		// default to the smaller tier so users opt into the surcharge. See microsoft/vscode#322950, microsoft/vscode#323116.
+		// Offer both sizes; default to the full window when long context is free, else the smaller tier.
 		return {
 			type: 'number',
 			title: localize('copilot.modelContextSize.title', "Context Size"),
@@ -1883,9 +1881,8 @@ export class CopilotAgent extends Disposable implements IAgent {
 	}
 
 	/**
-	 * Whether the model has a long-context window available at no additional cost. When true, a
-	 * session with no explicit context-size selection defaults to the `long_context` tier while the
-	 * picker still offers the smaller window.
+	 * Whether the model has a larger long-context window at no additional cost. When true, a session
+	 * with no explicit selection defaults to `long_context` while the picker still offers both sizes.
 	 */
 	private _isFreeLongContext(modelId: string | undefined): boolean {
 		return !!modelId && this._freeLongContextModels.has(modelId);
@@ -2119,8 +2116,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const result = models.map((m): IAgentModelInfo => {
 			const billing = normalizeCAPIBilling(m.billing);
 			const configSchema = this._createModelConfigSchema(m, billing);
-			// A model has free long context when it offers a larger long-context window at no
-			// surcharge. Such models default to the full window while the picker keeps both options.
+			// Free long context: a larger long-context window at no surcharge. Defaults to the full window; picker keeps both.
 			const tokenPrices = billing?.tokenPrices;
 			const hasLargerLongContext = !!tokenPrices?.contextMax
 				&& !!tokenPrices.longContext?.contextMax

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -35,11 +35,11 @@ import { workspacelessScratchDir } from '../workspacelessScratchDir.js';
 import { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
 import type { IAgentHostManagedSettingsPermissions } from '../../common/agentHostManagedSettings.js';
 import { IAgentHostReviewService } from '../../common/agentHostReviewService.js';
-import { createPricingMetaFromBilling, hasLongContextSurcharge, normalizeCAPIBilling, type ICAPIModelBilling } from '../../common/agentModelPricing.js';
+import { createPricingMetaFromBilling, normalizeCAPIBilling, type ICAPIModelBilling } from '../../common/agentModelPricing.js';
 import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema, DEFAULT_SESSION_CUSTOMIZATION_DISCOVERY_MODE, toContainerCustomization } from '../../common/agentHostCustomizationConfig.js';
 import { CopilotCliConfigKey, CopilotCliVSCodeAssignmentContextKey, copilotCliConfigSchema, DEFAULT_COPILOT_RUBBER_DUCK_ENABLED, type CopilotSdkLogLevelSetting } from '../../common/copilotCliConfig.js';
-import { AgentHostMcpServersConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AutoApproveLevel, SessionMode, migrateLegacyAutopilotConfig, platformRootSchema, platformSessionSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
+import { AgentHostMcpServersConfigKey, AgentHostCopilotMultiRootEnabledConfigKey, AgentHostSessionSyncEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey, AutoApproveLevel, SessionMode, migrateLegacyAutopilotConfig, platformRootSchema, platformSessionSchema, type AgentHostMcpServers } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { decodeProviderData, encodeProviderData, type IPersistedChat } from '../agentChatBackings.js';
 import { prepareSideChatPrompt, stripSideChatContext } from '../agentPeerChats.js';
@@ -573,9 +573,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 	private _capiModels: readonly IAgentModelInfo[] = [];
 	private _byokModels: readonly IAgentModelInfo[] = [];
 
-	/** Model IDs whose long-context tier costs the same as the default tier. */
-	private readonly _freeLongContextModels = new Set<string>();
-
 	/**
 	 * Bounded exponential-backoff retry for {@link _refreshModels}. The SDK's
 	 * `models.list` RPC can fail transiently (e.g. a `429 "too many requests"`
@@ -848,10 +845,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 
 	private _getEnterpriseHost(): string | undefined {
 		return this._gitHubEndpointService.getEnterpriseHost();
-	}
-
-	private _isPreferLongContextEnabled(): boolean {
-		return this._configurationService.getRootValue(platformRootSchema, AgentHostPreferLongContextEnabledConfigKey) === true;
 	}
 
 	private _isSystemProxyEnabled(): boolean {
@@ -1853,21 +1846,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 			return undefined;
 		}
 
-		// When both tiers cost the same and the user prefers long context, show only the long-context option as a non-switchable indicator. See microsoft/vscode#322950, microsoft/vscode#323116.
-		if (this._isPreferLongContextEnabled() && !hasLongContextSurcharge(billing)) {
-			return {
-				type: 'number',
-				title: localize('copilot.modelContextSize.title', "Context Size"),
-				description: localize('copilot.modelContextSize.description', "Selects the context window size for this model."),
-				default: longContextMax,
-				enum: [longContextMax],
-				enumLabels: [formatTokenCount(longContextMax)],
-				enumDescriptions: [
-					localize('copilot.modelContextSize.longerSessions', "Longer sessions"),
-				],
-			};
-		}
-
 		return {
 			type: 'number',
 			title: localize('copilot.modelContextSize.title', "Context Size"),
@@ -1896,15 +1874,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const windows = this._models.get().find(m => m.id === modelId)?.configSchema?.properties?.[ContextSizeConfigKey]?.enum;
 		const numericWindows = windows?.filter((w): w is number => typeof w === 'number');
 		return numericWindows && numericWindows.length > 0 ? Math.max(...numericWindows) : undefined;
-	}
-
-	/**
-	 * Whether the model has a long-context window available at no additional cost.
-	 * When true the model should always run in `long_context` tier without showing
-	 * a context-size picker.
-	 */
-	private _isFreeLongContext(modelId: string | undefined): boolean {
-		return !!modelId && this._freeLongContextModels.has(modelId);
 	}
 
 	/**
@@ -2131,19 +2100,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._logService.info('[Copilot] Listing models...');
 		const client = await this._ensureClient();
 		const { models } = await client.rpc.models.list({ gitHubToken });
-		this._freeLongContextModels.clear();
-		const preferLongContext = this._isPreferLongContextEnabled();
 		const result = models.map((m): IAgentModelInfo => {
 			const billing = normalizeCAPIBilling(m.billing);
 			const configSchema = this._createModelConfigSchema(m, billing);
-			// A model has free long context (larger window, no surcharge), but only treat it as free when the user prefers long context.
-			const tokenPrices = billing?.tokenPrices;
-			const hasLargerLongContext = !!tokenPrices?.contextMax
-				&& !!tokenPrices.longContext?.contextMax
-				&& tokenPrices.longContext.contextMax > tokenPrices.contextMax;
-			if (preferLongContext && hasLargerLongContext && !hasLongContextSurcharge(billing)) {
-				this._freeLongContextModels.add(m.id);
-			}
 			return {
 				provider: this.id,
 				id: m.id,
@@ -2736,7 +2695,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 				githubToken: this._githubToken,
 				model: provisional.model,
 				longContextWindow: this._longContextWindowFor(provisional.model?.id),
-				freeLongContext: this._isFreeLongContext(provisional.model?.id),
 				workspaceless: provisional.workspaceless,
 			};
 			const chatChannelUri = this._findBoundSessionChatUri(sdkSessionId) ?? sessionUri;
@@ -3232,7 +3190,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 					activeClientToolSet: activeClient.toolSet,
 					shellManager,
 					githubToken: this._githubToken,
-					fallback: { model, longContextWindow: this._longContextWindowFor(model?.id), freeLongContext: this._isFreeLongContext(model?.id) },
+					fallback: { model, longContextWindow: this._longContextWindowFor(model?.id) },
 				};
 			} else if (options.sideChat) {
 				const sideChatSource = await this._ensureResolvedChatSession(this._resolveChatContext(options.sideChat.source, { configurationResource: this._resolveChatScope(options.sideChat.source), resource: this._resolveChatStorageScope(options.sideChat.source) }));
@@ -3261,7 +3219,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 					activeClientToolSet: activeClient.toolSet,
 					shellManager,
 					githubToken: this._githubToken,
-					fallback: { model, longContextWindow: this._longContextWindowFor(model?.id), freeLongContext: this._isFreeLongContext(model?.id) },
+					fallback: { model, longContextWindow: this._longContextWindowFor(model?.id) },
 				};
 			} else {
 				sdkSessionId = chatSdkId;
@@ -3278,7 +3236,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 					githubToken: this._githubToken,
 					model,
 					longContextWindow: this._longContextWindowFor(model?.id),
-					freeLongContext: this._isFreeLongContext(model?.id),
 				};
 			}
 
@@ -3656,7 +3613,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 					activeClientToolSet: activeClient.toolSet,
 					shellManager,
 					githubToken: this._githubToken,
-					fallback: { model: info.model, longContextWindow: this._longContextWindowFor(info.model?.id), freeLongContext: this._isFreeLongContext(info.model?.id) },
+					fallback: { model: info.model, longContextWindow: this._longContextWindowFor(info.model?.id) },
 				};
 				agentSession = this._createAgentSession(launchPlan, workingDirectory, activeClient, { sessionUri: configurationResource, chatChannelUri: chat, resource: context.resource });
 				await agentSession.initializeSession();
@@ -3730,7 +3687,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 		await this._queueChat(context.configurationId, context.sequencerKey, async () => {
 			const current = this._resolveChatContext(chat, operationContext);
 			const longContextWindow = this._longContextWindowFor(model.id);
-			const freeLongContext = this._isFreeLongContext(model.id);
 			// A `family` alias routes the host's prompt and tool profile only. The
 			// selected model's reasoning-effort override is resolved separately.
 			const provisional = this._provisionalSessions.get(current.configurationId);
@@ -3738,7 +3694,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				provisional.model = model;
 			} else {
 				const entry = current.target ?? await this._ensureResolvedChatSession(current);
-				await entry?.setModel(model.id, resolveCopilotReasoningEffort(model, this._configurationService, this._logService, current.configurationId), getCopilotContextTier(model, longContextWindow, freeLongContext));
+				await entry?.setModel(model.id, resolveCopilotReasoningEffort(model, this._configurationService, this._logService, current.configurationId), getCopilotContextTier(model, longContextWindow));
 				// Keep the session-scope metadata in step for resumes that fall back
 				// to it; chat leaves persist through their backing instead.
 				if (current.resource.toString() === current.configurationResource.toString()) {
@@ -4111,7 +4067,6 @@ export class CopilotAgent extends Disposable implements IAgent {
 			fallback: {
 				model: storedMetadata.model,
 				longContextWindow: this._longContextWindowFor(storedMetadata.model?.id),
-				freeLongContext: this._isFreeLongContext(storedMetadata.model?.id),
 			},
 		};
 

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -35,7 +35,7 @@ import { workspacelessScratchDir } from '../workspacelessScratchDir.js';
 import { IAgentHostCheckpointService } from '../../common/agentHostCheckpointService.js';
 import type { IAgentHostManagedSettingsPermissions } from '../../common/agentHostManagedSettings.js';
 import { IAgentHostReviewService } from '../../common/agentHostReviewService.js';
-import { createPricingMetaFromBilling, normalizeCAPIBilling, type ICAPIModelBilling } from '../../common/agentModelPricing.js';
+import { createPricingMetaFromBilling, hasLongContextSurcharge, normalizeCAPIBilling, type ICAPIModelBilling } from '../../common/agentModelPricing.js';
 import { createAgentModelByokMeta } from '../../common/agentModelByokMeta.js';
 import { AgentHostConfigKey, agentHostCustomizationConfigSchema, DEFAULT_SESSION_CUSTOMIZATION_DISCOVERY_MODE, toContainerCustomization } from '../../common/agentHostCustomizationConfig.js';
 import { CopilotCliConfigKey, CopilotCliVSCodeAssignmentContextKey, copilotCliConfigSchema, DEFAULT_COPILOT_RUBBER_DUCK_ENABLED, type CopilotSdkLogLevelSetting } from '../../common/copilotCliConfig.js';
@@ -572,6 +572,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 	 */
 	private _capiModels: readonly IAgentModelInfo[] = [];
 	private _byokModels: readonly IAgentModelInfo[] = [];
+
+	/** Model IDs whose long-context tier costs the same as the default tier (free long context). */
+	private readonly _freeLongContextModels = new Set<string>();
 
 	/**
 	 * Bounded exponential-backoff retry for {@link _refreshModels}. The SDK's
@@ -1846,11 +1849,14 @@ export class CopilotAgent extends Disposable implements IAgent {
 			return undefined;
 		}
 
+		// Both options are always offered so the smaller window stays selectable. When the long
+		// context tier has no surcharge, default to the full window (free long context); otherwise
+		// default to the smaller tier so users opt into the surcharge. See microsoft/vscode#322950, microsoft/vscode#323116.
 		return {
 			type: 'number',
 			title: localize('copilot.modelContextSize.title', "Context Size"),
 			description: localize('copilot.modelContextSize.description', "Selects the context window size for this model."),
-			default: defaultMax,
+			default: hasLongContextSurcharge(billing) ? defaultMax : longContextMax,
 			enum: [defaultMax, longContextMax],
 			enumLabels: [formatTokenCount(defaultMax), formatTokenCount(longContextMax)],
 			enumDescriptions: [
@@ -1874,6 +1880,15 @@ export class CopilotAgent extends Disposable implements IAgent {
 		const windows = this._models.get().find(m => m.id === modelId)?.configSchema?.properties?.[ContextSizeConfigKey]?.enum;
 		const numericWindows = windows?.filter((w): w is number => typeof w === 'number');
 		return numericWindows && numericWindows.length > 0 ? Math.max(...numericWindows) : undefined;
+	}
+
+	/**
+	 * Whether the model has a long-context window available at no additional cost. When true, a
+	 * session with no explicit context-size selection defaults to the `long_context` tier while the
+	 * picker still offers the smaller window.
+	 */
+	private _isFreeLongContext(modelId: string | undefined): boolean {
+		return !!modelId && this._freeLongContextModels.has(modelId);
 	}
 
 	/**
@@ -2100,9 +2115,19 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._logService.info('[Copilot] Listing models...');
 		const client = await this._ensureClient();
 		const { models } = await client.rpc.models.list({ gitHubToken });
+		this._freeLongContextModels.clear();
 		const result = models.map((m): IAgentModelInfo => {
 			const billing = normalizeCAPIBilling(m.billing);
 			const configSchema = this._createModelConfigSchema(m, billing);
+			// A model has free long context when it offers a larger long-context window at no
+			// surcharge. Such models default to the full window while the picker keeps both options.
+			const tokenPrices = billing?.tokenPrices;
+			const hasLargerLongContext = !!tokenPrices?.contextMax
+				&& !!tokenPrices.longContext?.contextMax
+				&& tokenPrices.longContext.contextMax > tokenPrices.contextMax;
+			if (hasLargerLongContext && !hasLongContextSurcharge(billing)) {
+				this._freeLongContextModels.add(m.id);
+			}
 			return {
 				provider: this.id,
 				id: m.id,
@@ -2695,6 +2720,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				githubToken: this._githubToken,
 				model: provisional.model,
 				longContextWindow: this._longContextWindowFor(provisional.model?.id),
+				freeLongContext: this._isFreeLongContext(provisional.model?.id),
 				workspaceless: provisional.workspaceless,
 			};
 			const chatChannelUri = this._findBoundSessionChatUri(sdkSessionId) ?? sessionUri;
@@ -3190,7 +3216,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 					activeClientToolSet: activeClient.toolSet,
 					shellManager,
 					githubToken: this._githubToken,
-					fallback: { model, longContextWindow: this._longContextWindowFor(model?.id) },
+					fallback: { model, longContextWindow: this._longContextWindowFor(model?.id), freeLongContext: this._isFreeLongContext(model?.id) },
 				};
 			} else if (options.sideChat) {
 				const sideChatSource = await this._ensureResolvedChatSession(this._resolveChatContext(options.sideChat.source, { configurationResource: this._resolveChatScope(options.sideChat.source), resource: this._resolveChatStorageScope(options.sideChat.source) }));
@@ -3219,7 +3245,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 					activeClientToolSet: activeClient.toolSet,
 					shellManager,
 					githubToken: this._githubToken,
-					fallback: { model, longContextWindow: this._longContextWindowFor(model?.id) },
+					fallback: { model, longContextWindow: this._longContextWindowFor(model?.id), freeLongContext: this._isFreeLongContext(model?.id) },
 				};
 			} else {
 				sdkSessionId = chatSdkId;
@@ -3236,6 +3262,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 					githubToken: this._githubToken,
 					model,
 					longContextWindow: this._longContextWindowFor(model?.id),
+					freeLongContext: this._isFreeLongContext(model?.id),
 				};
 			}
 
@@ -3613,7 +3640,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 					activeClientToolSet: activeClient.toolSet,
 					shellManager,
 					githubToken: this._githubToken,
-					fallback: { model: info.model, longContextWindow: this._longContextWindowFor(info.model?.id) },
+					fallback: { model: info.model, longContextWindow: this._longContextWindowFor(info.model?.id), freeLongContext: this._isFreeLongContext(info.model?.id) },
 				};
 				agentSession = this._createAgentSession(launchPlan, workingDirectory, activeClient, { sessionUri: configurationResource, chatChannelUri: chat, resource: context.resource });
 				await agentSession.initializeSession();
@@ -3687,6 +3714,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		await this._queueChat(context.configurationId, context.sequencerKey, async () => {
 			const current = this._resolveChatContext(chat, operationContext);
 			const longContextWindow = this._longContextWindowFor(model.id);
+			const freeLongContext = this._isFreeLongContext(model.id);
 			// A `family` alias routes the host's prompt and tool profile only. The
 			// selected model's reasoning-effort override is resolved separately.
 			const provisional = this._provisionalSessions.get(current.configurationId);
@@ -3694,7 +3722,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 				provisional.model = model;
 			} else {
 				const entry = current.target ?? await this._ensureResolvedChatSession(current);
-				await entry?.setModel(model.id, resolveCopilotReasoningEffort(model, this._configurationService, this._logService, current.configurationId), getCopilotContextTier(model, longContextWindow));
+				await entry?.setModel(model.id, resolveCopilotReasoningEffort(model, this._configurationService, this._logService, current.configurationId), getCopilotContextTier(model, longContextWindow, freeLongContext));
 				// Keep the session-scope metadata in step for resumes that fall back
 				// to it; chat leaves persist through their backing instead.
 				if (current.resource.toString() === current.configurationResource.toString()) {
@@ -4067,6 +4095,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 			fallback: {
 				model: storedMetadata.model,
 				longContextWindow: this._longContextWindowFor(storedMetadata.model?.id),
+				freeLongContext: this._isFreeLongContext(storedMetadata.model?.id),
 			},
 		};
 

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -237,6 +237,7 @@ export interface ICopilotCreateSessionLaunchPlan extends ICopilotSessionLaunchBa
 	readonly kind: 'create';
 	readonly model: ModelSelection | undefined;
 	readonly longContextWindow?: number;
+	readonly freeLongContext?: boolean;
 }
 
 export interface ICopilotResumeSessionLaunchPlan extends ICopilotSessionLaunchBase {
@@ -245,6 +246,7 @@ export interface ICopilotResumeSessionLaunchPlan extends ICopilotSessionLaunchBa
 	readonly fallback: {
 		readonly model: ModelSelection | undefined;
 		readonly longContextWindow?: number;
+		readonly freeLongContext?: boolean;
 	};
 }
 
@@ -398,7 +400,7 @@ function getToolFilterOverride(value: string | readonly string[] | undefined, fi
 	return patterns;
 }
 
-export function getCopilotContextTier(model: ModelSelection | undefined, longContextWindow?: number): SessionConfig['contextTier'] {
+export function getCopilotContextTier(model: ModelSelection | undefined, longContextWindow?: number, freeLongContext?: boolean): SessionConfig['contextTier'] {
 	// Legacy persisted selections stored the resolved tier string directly under the deprecated key.
 	const legacyTier = model?.config?.[ContextTierConfigKey];
 	if (isContextTier(legacyTier)) {
@@ -411,7 +413,9 @@ export function getCopilotContextTier(model: ModelSelection | undefined, longCon
 	// tier.
 	const contextSize = model?.config?.[ContextSizeConfigKey];
 	if (contextSize === undefined) {
-		return undefined;
+		// No explicit selection: default free long-context models (larger window, no surcharge) to
+		// the full window while the picker keeps both options; leave surcharged models on the SDK default tier.
+		return freeLongContext ? 'long_context' : undefined;
 	}
 	const selectedWindow = Number(contextSize);
 	if (!Number.isFinite(selectedWindow) || typeof longContextWindow !== 'number') {
@@ -568,6 +572,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 				kind: 'create',
 				model: fallbackPlan.fallback.model,
 				longContextWindow: fallbackPlan.fallback.longContextWindow,
+				freeLongContext: fallbackPlan.fallback.freeLongContext,
 			}, fallbackConfig, sandboxConfig);
 			this._logService.info(`[Copilot:${plan.sessionId}] Fallback createSession succeeded`);
 			return wrapper;
@@ -586,7 +591,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			streaming: true,
 			model: plan.model?.id,
 			reasoningEffort: resolveCopilotReasoningEffort(plan.model, this._configurationService, this._logService, plan.sessionId),
-			contextTier: getCopilotContextTier(plan.model, plan.longContextWindow),
+			contextTier: getCopilotContextTier(plan.model, plan.longContextWindow, plan.freeLongContext),
 			...(plan.resolvedAgentName ? { agent: plan.resolvedAgentName } : {}),
 			workingDirectory: plan.workingDirectory?.fsPath,
 		}));

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -237,7 +237,6 @@ export interface ICopilotCreateSessionLaunchPlan extends ICopilotSessionLaunchBa
 	readonly kind: 'create';
 	readonly model: ModelSelection | undefined;
 	readonly longContextWindow?: number;
-	readonly freeLongContext?: boolean;
 }
 
 export interface ICopilotResumeSessionLaunchPlan extends ICopilotSessionLaunchBase {
@@ -246,7 +245,6 @@ export interface ICopilotResumeSessionLaunchPlan extends ICopilotSessionLaunchBa
 	readonly fallback: {
 		readonly model: ModelSelection | undefined;
 		readonly longContextWindow?: number;
-		readonly freeLongContext?: boolean;
 	};
 }
 
@@ -400,7 +398,7 @@ function getToolFilterOverride(value: string | readonly string[] | undefined, fi
 	return patterns;
 }
 
-export function getCopilotContextTier(model: ModelSelection | undefined, longContextWindow?: number, freeLongContext?: boolean): SessionConfig['contextTier'] {
+export function getCopilotContextTier(model: ModelSelection | undefined, longContextWindow?: number): SessionConfig['contextTier'] {
 	// Legacy persisted selections stored the resolved tier string directly under the deprecated key.
 	const legacyTier = model?.config?.[ContextTierConfigKey];
 	if (isContextTier(legacyTier)) {
@@ -413,10 +411,7 @@ export function getCopilotContextTier(model: ModelSelection | undefined, longCon
 	// tier.
 	const contextSize = model?.config?.[ContextSizeConfigKey];
 	if (contextSize === undefined) {
-		// When the model's long-context tier costs the same as the default tier,
-		// always opt into long_context — no picker is shown and the user gets the
-		// larger window for free.
-		return freeLongContext ? 'long_context' : undefined;
+		return undefined;
 	}
 	const selectedWindow = Number(contextSize);
 	if (!Number.isFinite(selectedWindow) || typeof longContextWindow !== 'number') {
@@ -573,7 +568,6 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 				kind: 'create',
 				model: fallbackPlan.fallback.model,
 				longContextWindow: fallbackPlan.fallback.longContextWindow,
-				freeLongContext: fallbackPlan.fallback.freeLongContext,
 			}, fallbackConfig, sandboxConfig);
 			this._logService.info(`[Copilot:${plan.sessionId}] Fallback createSession succeeded`);
 			return wrapper;
@@ -592,7 +586,7 @@ export class CopilotSessionLauncher implements ICopilotSessionLauncher {
 			streaming: true,
 			model: plan.model?.id,
 			reasoningEffort: resolveCopilotReasoningEffort(plan.model, this._configurationService, this._logService, plan.sessionId),
-			contextTier: getCopilotContextTier(plan.model, plan.longContextWindow, plan.freeLongContext),
+			contextTier: getCopilotContextTier(plan.model, plan.longContextWindow),
 			...(plan.resolvedAgentName ? { agent: plan.resolvedAgentName } : {}),
 			workingDirectory: plan.workingDirectory?.fsPath,
 		}));

--- a/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotSessionLauncher.ts
@@ -413,8 +413,7 @@ export function getCopilotContextTier(model: ModelSelection | undefined, longCon
 	// tier.
 	const contextSize = model?.config?.[ContextSizeConfigKey];
 	if (contextSize === undefined) {
-		// No explicit selection: default free long-context models (larger window, no surcharge) to
-		// the full window while the picker keeps both options; leave surcharged models on the SDK default tier.
+		// No selection: free long context defaults to the full window; other models stay on the SDK default tier.
 		return freeLongContext ? 'long_context' : undefined;
 	}
 	const selectedWindow = Number(contextSize);

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -3585,7 +3585,7 @@ suite('CopilotAgent', () => {
 		}
 	});
 
-	test('configSchema shows both context options by default when long_context tier has no surcharge', async () => {
+	test('configSchema shows both context options with the longer window as default when long_context tier has no surcharge', async () => {
 		const agent = createTestAgent(disposables, {
 			copilotClient: new TestCopilotClient([], [{
 				id: 'free-long-context',
@@ -3607,7 +3607,7 @@ suite('CopilotAgent', () => {
 			const contextSize = models[0].configSchema?.properties?.contextSize;
 			assert.strictEqual(contextSize?.type, 'number');
 			assert.deepStrictEqual(contextSize?.enum, [200_000, 1_000_000]);
-			assert.strictEqual(contextSize?.default, 200_000);
+			assert.strictEqual(contextSize?.default, 1_000_000);
 			assert.deepStrictEqual(contextSize?.enumLabels, ['200K', '1M']);
 		} finally {
 			await disposeAgent(agent);
@@ -3679,7 +3679,7 @@ suite('CopilotAgent', () => {
 			assert.strictEqual(config.contextTier, 'long_context');
 		});
 
-		test('leaves the SDK on its default tier when model has no surcharge and no explicit selection', async () => {
+		test('defaults to long_context when model has no surcharge and no explicit selection (free long context)', async () => {
 			const freeLongContextModel: ITestCopilotModelInfo = {
 				id: 'free-long-ctx',
 				name: 'Free Long Ctx',
@@ -3694,7 +3694,7 @@ suite('CopilotAgent', () => {
 			};
 			const config = await captureSessionConfig({ id: 'free-long-ctx' }, [freeLongContextModel]);
 			assert.ok(config);
-			assert.strictEqual(config.contextTier, undefined);
+			assert.strictEqual(config.contextTier, 'long_context');
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -36,7 +36,7 @@ import { NullTelemetryService, NullTelemetryServiceShape } from '../../../teleme
 import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
 import { CopilotCliConfigKey, CopilotCliVSCodeAssignmentContextKey } from '../../common/copilotCliConfig.js';
 import { AgentHostConfigKey } from '../../common/agentHostCustomizationConfig.js';
-import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostPreferLongContextEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
+import { AgentHostCopilotMultiRootEnabledConfigKey, AgentHostMigrateLegacyCopilotCliEnabledConfigKey, AgentHostSystemProxyEnabledConfigKey } from '../../common/agentHostSchema.js';
 import { IAgentPluginManager, ISyncedCustomization } from '../../common/agentPluginManager.js';
 import { getTelemetryChatSessionId } from '../../common/agentTelemetryCorrelation.js';
 import { AgentSession, GITHUB_COPILOT_PROTECTED_RESOURCE, type AgentSignal, type IAgentChatContext, type IAgentChatMetadata, type IAgentCreateChatForkSource, type IAgentCreateChatOptions, type IAgentCreateChatResult, type IAgentCreateSessionConfig, type IAgentMaterializeChatEvent, type IAgentSpawnChatEvent } from '../../common/agent.js';
@@ -3614,36 +3614,6 @@ suite('CopilotAgent', () => {
 		}
 	});
 
-	test('configSchema shows only long context option when long_context tier has no surcharge and preferLongContext is enabled', async () => {
-		const { agent, configurationService } = createTestAgentContext(disposables, {
-			copilotClient: new TestCopilotClient([], [{
-				id: 'free-long-context',
-				name: 'Free Long Context',
-				capabilities: { limits: { max_context_window_tokens: 200_000 } },
-				billing: {
-					multiplier: 1,
-					tokenPrices: {
-						contextMax: 200_000,
-						longContext: { contextMax: 1_000_000 },
-					},
-				},
-			}]),
-		});
-		try {
-			configurationService.updateRootConfig({ [AgentHostPreferLongContextEnabledConfigKey]: true });
-			await agent.authenticate('https://api.github.com', 'token');
-			const models = await waitForState(agent.models, models => models.length > 0);
-
-			const contextSize = models[0].configSchema?.properties?.contextSize;
-			assert.strictEqual(contextSize?.type, 'number');
-			assert.deepStrictEqual(contextSize?.enum, [1_000_000]);
-			assert.strictEqual(contextSize?.default, 1_000_000);
-			assert.deepStrictEqual(contextSize?.enumLabels, ['1M']);
-		} finally {
-			await disposeAgent(agent);
-		}
-	});
-
 	suite('contextSize to contextTier mapping', () => {
 		const longContextModel: ITestCopilotModelInfo = {
 			id: 'claude-sonnet',
@@ -3658,7 +3628,7 @@ suite('CopilotAgent', () => {
 			},
 		};
 
-		async function captureSessionConfig(model: ModelSelection | undefined, models: readonly ITestCopilotModelInfo[], preferLongContext?: boolean): Promise<CopilotCreateSessionOptions | undefined> {
+		async function captureSessionConfig(model: ModelSelection | undefined, models: readonly ITestCopilotModelInfo[]): Promise<CopilotCreateSessionOptions | undefined> {
 			const sessionDataService = disposables.add(new TestSessionDataService());
 			const client = new TestCopilotClient([], models);
 			let capturedConfig: CopilotCreateSessionOptions | undefined;
@@ -3666,11 +3636,8 @@ suite('CopilotAgent', () => {
 				capturedConfig = config;
 				return new MockCopilotSession() as unknown as CopilotSession;
 			};
-			const { agent, configurationService } = createTestAgentContext(disposables, { sessionDataService, copilotClient: client });
+			const { agent } = createTestAgentContext(disposables, { sessionDataService, copilotClient: client });
 			try {
-				if (preferLongContext) {
-					configurationService.updateRootConfig({ [AgentHostPreferLongContextEnabledConfigKey]: true });
-				}
 				await agent.authenticate('https://api.github.com', 'token');
 				await waitForState(agent.models, m => m.length > 0);
 				const result = await provisionSession(agent, {
@@ -3728,24 +3695,6 @@ suite('CopilotAgent', () => {
 			const config = await captureSessionConfig({ id: 'free-long-ctx' }, [freeLongContextModel]);
 			assert.ok(config);
 			assert.strictEqual(config.contextTier, undefined);
-		});
-
-		test('uses long_context when model has no surcharge, no explicit selection and preferLongContext is enabled', async () => {
-			const freeLongContextModel: ITestCopilotModelInfo = {
-				id: 'free-long-ctx',
-				name: 'Free Long Ctx',
-				capabilities: { limits: { max_context_window_tokens: 200_000 } },
-				billing: {
-					multiplier: 1,
-					tokenPrices: {
-						contextMax: 200_000,
-						longContext: { contextMax: 1_000_000 },
-					},
-				},
-			};
-			const config = await captureSessionConfig({ id: 'free-long-ctx' }, [freeLongContextModel], true);
-			assert.ok(config);
-			assert.strictEqual(config.contextTier, 'long_context');
 		});
 	});
 


### PR DESCRIPTION
Revert to showing all context size options.

Removes the `github.copilot.chat.preferLongContext.enabled` setting and always shows **both** the default and long-context options in the model picker (no longer hides the smaller option).

**Default selection:** when the long-context tier has **no surcharge** (free long context), the picker — and the no-selection behavioral fallback — defaults to the **full/longer window**. Models where long context costs more still default to the smaller tier so users explicitly opt into the surcharge. Applied consistently across the main chat picker, the Copilot CLI picker, and the agent host.

### Reverts
- https://github.com/microsoft/vscode/pull/322950 — hide long context for models which have the same cost
- https://github.com/microsoft/vscode/pull/323116 — if long context = default context, show a single long context option in picker
- https://github.com/microsoft/vscode/pull/324650 — add it behind a setting
- https://github.com/microsoft/vscode/pull/328628 — make the setting default `true`. Incorrect — I meant to flip it to `false`.


