### PR TITLE
fix: memory leak in scm repository menus

### DIFF
--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -760,6 +760,9 @@ export class Configuration {
 
 		if (value === undefined) {
 			memoryConfiguration.removeValue(key);
+			if (overrides.resource && memoryConfiguration.isEmpty()) {
+				this._memoryConfigurationByResource.delete(overrides.resource);
+			}
 		} else {
 			memoryConfiguration.setValue(key, value);
 		}

--- a/src/vs/platform/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationModels.test.ts
@@ -813,6 +813,7 @@ suite('CustomConfigurationModel', () => {
 });
 
 export class TestConfiguration extends Configuration {
+	readonly memoryConfigurationByResource: ResourceMap<ConfigurationModel>;
 
 	constructor(
 		defaultConfiguration: ConfigurationModel,
@@ -820,6 +821,7 @@ export class TestConfiguration extends Configuration {
 		applicationConfiguration: ConfigurationModel,
 		localUserConfiguration: ConfigurationModel,
 		remoteUserConfiguration?: ConfigurationModel,
+		memoryConfigurationByResource = new ResourceMap<ConfigurationModel>(),
 	) {
 		super(
 			defaultConfiguration,
@@ -830,9 +832,10 @@ export class TestConfiguration extends Configuration {
 			ConfigurationModel.createEmptyModel(new NullLogService()),
 			new ResourceMap<ConfigurationModel>(),
 			ConfigurationModel.createEmptyModel(new NullLogService()),
-			new ResourceMap<ConfigurationModel>(),
+			memoryConfigurationByResource,
 			new NullLogService()
 		);
+		this.memoryConfigurationByResource = memoryConfigurationByResource;
 	}
 
 }
@@ -871,6 +874,17 @@ suite('Configuration', () => {
 		testObject.updateValue('a', 2);
 
 		assert.strictEqual(testObject.getValue('a', {}, undefined), 2);
+	});
+
+	test('Test remove empty resource memory configuration', () => {
+		const testObject = new TestConfiguration(ConfigurationModel.createEmptyModel(new NullLogService()), ConfigurationModel.createEmptyModel(new NullLogService()), ConfigurationModel.createEmptyModel(new NullLogService()), ConfigurationModel.createEmptyModel(new NullLogService()));
+		const resource = URI.file('/workspace/repository');
+
+		testObject.updateValue('a', 2, { resource });
+		assert.strictEqual(testObject.memoryConfigurationByResource.size, 1);
+
+		testObject.updateValue('a', undefined, { resource });
+		assert.strictEqual(testObject.memoryConfigurationByResource.size, 0);
 	});
 
 	test('Test compare and update default configuration', () => {

--- a/src/vs/workbench/contrib/scm/browser/menus.ts
+++ b/src/vs/workbench/contrib/scm/browser/menus.ts
@@ -365,6 +365,16 @@ export class SCMRepositoryMenus implements ISCMRepositoryMenus, IDisposable {
 			this.contextualRepositoryMenus.clear();
 			this.contextualRepositoryMenus = undefined;
 		}
+		this.genericRepositoryContextMenu?.dispose();
+		if (this.contextualRepositoryContextMenus) {
+			dispose(this.contextualRepositoryContextMenus.values());
+			this.contextualRepositoryContextMenus.clear();
+			this.contextualRepositoryContextMenus = undefined;
+		}
+		dispose(this.artifactGroupMenus.values());
+		this.artifactGroupMenus.clear();
+		dispose(this.artifactMenus.values());
+		this.artifactMenus.clear();
 		this.resourceGroupMenusItems.forEach(item => item.dispose());
 		this.disposables.dispose();
 	}

--- a/src/vs/workbench/contrib/scm/browser/scmInput.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmInput.ts
@@ -5,7 +5,7 @@
 
 import './media/scm.css';
 import { Event, Emitter } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { append, $, Dimension, trackFocus } from '../../../../base/browser/dom.js';
 import { InputValidationType, ISCMInput, IInputValidation, ISCMViewService, SCMInputChangeReason, ISCMInputValueProviderContext } from '../common/scm.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -411,7 +411,10 @@ export class SCMInputWidget {
 		this.inputEditor.setModel(textModel);
 
 		if (this.configurationService.getValue('editor.wordBasedSuggestions', { resource: textModel.uri }) !== 'off') {
-			this.configurationService.updateValue('editor.wordBasedSuggestions', 'off', { resource: textModel.uri }, ConfigurationTarget.MEMORY);
+			void this.configurationService.updateValue('editor.wordBasedSuggestions', 'off', { resource: textModel.uri }, ConfigurationTarget.MEMORY);
+			this.repositoryDisposables.add(toDisposable(() => {
+				void this.configurationService.updateValue('editor.wordBasedSuggestions', undefined, { resource: textModel.uri }, ConfigurationTarget.MEMORY);
+			}));
 		}
 
 		// Validation

--- a/src/vs/workbench/contrib/scm/test/browser/menus.test.ts
+++ b/src/vs/workbench/contrib/scm/test/browser/menus.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Event } from '../../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { IMenu, IMenuActionOptions, IMenuCreateOptions, IMenuService, MenuId } from '../../../../../platform/actions/common/actions.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { SCMRepositoryMenus } from '../../browser/menus.js';
+import { ISCMProvider, ISCMRepository } from '../../common/scm.js';
+
+class TestMenuService implements IMenuService {
+
+	declare readonly _serviceBrand: undefined;
+
+	private readonly menus = new Map<MenuId, { disposed: boolean }>();
+
+	createMenu(id: MenuId, _contextKeyService: IContextKeyService, _options?: IMenuCreateOptions): IMenu {
+		const state = { disposed: false };
+		this.menus.set(id, state);
+
+		return {
+			onDidChange: Event.None,
+			getActions: () => [],
+			dispose: () => state.disposed = true,
+		};
+	}
+
+	getMenuActions(_id: MenuId, _contextKeyService: IContextKeyService, _options?: IMenuActionOptions) {
+		return [];
+	}
+
+	getMenuContexts(_id: MenuId): ReadonlySet<string> {
+		return new Set<string>();
+	}
+
+	resetHiddenStates(_menuIds?: readonly MenuId[]): void { }
+
+	isDisposed(id: MenuId): boolean {
+		return this.menus.get(id)?.disposed ?? false;
+	}
+}
+
+suite('SCMRepositoryMenus', () => {
+
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('disposes repository context menu', () => {
+		const contextKeyService = new MockContextKeyService();
+		const menuService = new TestMenuService();
+		const instantiationService = disposables.add(new TestInstantiationService());
+		instantiationService.set(IContextKeyService, contextKeyService);
+		instantiationService.set(IMenuService, menuService);
+
+		const provider = {
+			contextValue: { get: () => 'git' },
+			groups: [],
+			onDidChangeResourceGroups: Event.None,
+			providerId: 'git',
+		} as unknown as ISCMProvider;
+		const repository = { provider } as ISCMRepository;
+		const menus = new SCMRepositoryMenus(provider, contextKeyService, instantiationService, menuService);
+
+		menus.getRepositoryContextMenu(repository);
+		menus.dispose();
+
+		assert.strictEqual(menuService.isDisposed(MenuId.SCMSourceControl), true);
+	});
+});


### PR DESCRIPTION
### Details

SCM repository context menus and resource-scoped input configuration overrides outlived repositories after they were removed from the Source Control view.

### Change

Dispose every menu owned by an SCM repository, release the input's temporary word-suggestion override, and remove empty resource memory configurations.

### Before

When a Git repository was closed and reopened 37 times, SCM menu and configuration objects grew by 37 instances each.

<img width="1400" height="140" alt="before" src="https://github.com/user-attachments/assets/584b9afa-2e6b-4f39-8827-959c9a8121d9" />

### After

No more SCM repository menu or resource configuration growth is detected.

### Test Video

[test-video.webm](https://github.com/user-attachments/assets/5f872b8a-3c1a-4acb-b7a4-1c179238c195)
