### PR TITLE
sessions: Show live last turn changes

### DIFF
--- a/src/vs/sessions/SESSIONS.md
+++ b/src/vs/sessions/SESSIONS.md
@@ -180,9 +180,12 @@ provider supports it.
 
 Turn-level file changes open through `IChatResponseFileChangesService`. The
 Editor workbench opens a standalone multi-diff, while the Agents Window selects
-the canonical Changes editor. Its moving last-turn changeset follows the most
-recently modified chat; historical turns and other chats use a transient
-selection backed by their exact per-turn changes.
+the canonical Changes editor. The active-turn pill uses a transient selection
+backed by the viewed chat's live `lastTurnChanges` observable so streamed edits
+appear before turn completion. The completed latest-response pill selects the
+provider's moving last-turn changeset, which follows the most recently modified
+chat; historical turns and other completed chats use a transient selection
+backed by their exact per-turn changes.
 
 Presentation and layout of changes are documented in [LAYOUT.md](LAYOUT.md).
 Provider translation and transport details belong in the relevant provider

--- a/src/vs/sessions/contrib/chat/browser/sessionTurnChanges.ts
+++ b/src/vs/sessions/contrib/chat/browser/sessionTurnChanges.ts
@@ -42,21 +42,22 @@ export class SessionsChatResponseFileChangesService extends AbstractChatResponse
 			return;
 		}
 		if (context.isLastTurn) {
+			if (requestId === undefined) {
+				const changes = owner.chat.lastTurnChanges;
+				if (changes) {
+					this._openTransientLastTurnChanges(owner.session, owner.chat.resource.toString(), changes);
+				}
+				return;
+			}
+
 			if (this._isMostRecentChat(owner.session, owner.chat)) {
 				void this._openSessionTurnChanges(owner.session);
 				return;
 			}
 
-			const changes = requestId === undefined
-				? owner.chat.lastTurnChanges
-				: this._getSessionFileChanges(chatResource, requestId);
+			const changes = this._getSessionFileChanges(chatResource, requestId);
 			if (changes) {
-				void this._openSessionTurnChanges(owner.session, {
-					id: `${TURN_CHANGES_CHANGESET_ID}:${requestId ?? owner.chat.resource.toString()}`,
-					label: localize('lastTurnChanges.label', "Last Turn Changes"),
-					description: localize('lastTurnChanges.description', "Changes from the viewed chat's last turn."),
-					changes,
-				});
+				this._openTransientLastTurnChanges(owner.session, requestId, changes);
 			}
 			return;
 		}
@@ -117,6 +118,15 @@ export class SessionsChatResponseFileChangesService extends AbstractChatResponse
 			insertions: diff.added,
 			deletions: diff.removed,
 		})));
+	}
+
+	private _openTransientLastTurnChanges(session: ISession, id: string, changes: IObservable<readonly ISessionFileChange[]>): void {
+		void this._openSessionTurnChanges(session, {
+			id: `${TURN_CHANGES_CHANGESET_ID}:${id}`,
+			label: localize('lastTurnChanges.label', "Last Turn Changes"),
+			description: localize('lastTurnChanges.description', "Changes from the viewed chat's last turn."),
+			changes,
+		});
 	}
 
 	private async _openSessionTurnChanges(session: ISession, transientTurn?: ISessionTransientTurnChanges): Promise<void> {

--- a/src/vs/sessions/contrib/chat/test/browser/sessionTurnChanges.test.ts
+++ b/src/vs/sessions/contrib/chat/test/browser/sessionTurnChanges.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
-import { constObservable } from '../../../../../base/common/observable.js';
+import { constObservable, IObservable, observableValue } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { mock, upcastPartial } from '../../../../../base/test/common/mock.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
@@ -12,7 +12,7 @@ import { isIChatSessionFileChange2 } from '../../../../../workbench/contrib/chat
 import { IEditorService } from '../../../../../workbench/services/editor/common/editorService.js';
 import { IAgentWorkbenchLayoutService } from '../../../../browser/workbench.js';
 import { ISessionsService } from '../../../../services/sessions/browser/sessionsService.js';
-import { IChat, TURN_CHANGES_CHANGESET_ID } from '../../../../services/sessions/common/session.js';
+import { IChat, ISessionFileChange, ISessionTurnFileChange, TURN_CHANGES_CHANGESET_ID } from '../../../../services/sessions/common/session.js';
 import { IActiveSession, ISessionsManagementService } from '../../../../services/sessions/common/sessionsManagement.js';
 import { ISessionChangesEditorOptions, ISessionChangesService } from '../../../changes/browser/sessionChangesService.js';
 import { SessionsChatResponseFileChangesService } from '../../browser/sessionTurnChanges.js';
@@ -20,11 +20,20 @@ import { SessionsChatResponseFileChangesService } from '../../browser/sessionTur
 suite('SessionTurnChanges', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('activates the session and opens its last-turn changeset', () => {
+	test('activates the session and opens live input-pill changes', () => {
 		const chatResource = URI.parse('chat:session');
+		const lastTurnChanges = observableValue<readonly ISessionTurnFileChange[]>('lastTurnChanges', [{
+			uri: URI.file('/workspace/first.ts'),
+			originalUri: URI.parse('agenthost:/snapshots/first-before'),
+			modifiedUri: URI.file('/workspace/first.ts'),
+			insertions: 1,
+			deletions: 0,
+			isOutsideWorkspace: false,
+		}]);
 		const chat = upcastPartial<IChat>({
 			resource: chatResource,
 			updatedAt: constObservable(new Date('2026-08-13T10:00:00Z')),
+			lastTurnChanges,
 		});
 		const session = upcastPartial<IActiveSession>({
 			resource: URI.parse('agent-host:session'),
@@ -32,6 +41,7 @@ suite('SessionTurnChanges', () => {
 			mainChat: constObservable(chat),
 		});
 		const calls: object[] = [];
+		let selectedChanges: IObservable<readonly ISessionFileChange[]> | undefined;
 		const sessionsManagementService = new class extends mock<ISessionsManagementService>() {
 			override getSessionForChatResource() {
 				return { session, chat };
@@ -48,8 +58,9 @@ suite('SessionTurnChanges', () => {
 				const selection = options?.changesetSelection;
 				calls.push({
 					openChangesEditor: sessionResource.toString(),
-					changesetId: selection?.kind === 'id' ? selection.id : undefined,
+					changesetId: selection?.kind === 'transient' ? selection.changeset.id : selection?.id,
 				});
+				selectedChanges = selection?.kind === 'transient' ? selection.changeset.changes : undefined;
 				return undefined;
 			}
 		}();
@@ -67,12 +78,25 @@ suite('SessionTurnChanges', () => {
 		));
 
 		service.openChangesForRequest(chatResource, undefined, { isLastTurn: true });
+		lastTurnChanges.set([{
+			uri: URI.file('/workspace/second.ts'),
+			modifiedUri: URI.file('/workspace/second.ts'),
+			insertions: 2,
+			deletions: 1,
+			isOutsideWorkspace: false,
+		}], undefined);
 
-		assert.deepStrictEqual(calls, [
-			{ showSession: session.resource.toString(), preserveFocus: true },
-			{ revealEditorPartExplicitly: true },
-			{ openChangesEditor: session.resource.toString(), changesetId: TURN_CHANGES_CHANGESET_ID },
-		]);
+		assert.deepStrictEqual({
+			calls,
+			selectedChanges: selectedChanges?.get().map(change => isIChatSessionFileChange2(change) ? change.uri.toString() : undefined),
+		}, {
+			calls: [
+				{ showSession: session.resource.toString(), preserveFocus: true },
+				{ revealEditorPartExplicitly: true },
+				{ openChangesEditor: session.resource.toString(), changesetId: 'turn:chat:session' },
+			],
+			selectedChanges: ['file:///workspace/second.ts'],
+		});
 	});
 
 	test('opens exact historical request changes as a transient changeset', () => {


### PR DESCRIPTION
Fixes a regression after #330620 where clicking the active-turn Changes pill opened an empty Changes view until the Agent Host turn completed.

The active input pill now opens a transient Last Turn Changes selection backed by the viewed chat’s live `IChat.lastTurnChanges` observable. Completed latest-response pills continue to select the canonical provider changeset, while historical response behavior remains unchanged.

Validation:
- `npm run transpile-client`
- `./scripts/test.sh --run src/vs/sessions/contrib/chat/test/browser/sessionTurnChanges.test.ts`
- `npm run typecheck-client`
- `npm run valid-layers-check`
- `npm run hygiene`