### PR TITLE
Avoid unhandled deferred IPC cancellation rejections

### DIFF
--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -640,7 +640,7 @@ export class ChannelClient implements IChannelClient, IDisposable {
 				uninitializedPromise.then(() => {
 					uninitializedPromise = null;
 					doRequest();
-				});
+				}, () => { });
 			}
 
 			const cancel = () => {
@@ -693,7 +693,7 @@ export class ChannelClient implements IChannelClient, IDisposable {
 					uninitializedPromise.then(() => {
 						uninitializedPromise = null;
 						doRequest();
-					});
+					}, () => { });
 				}
 			},
 			onDidRemoveLastListener: () => {

--- a/src/vs/base/parts/ipc/test/node/ipc.cp.integrationTest.ts
+++ b/src/vs/base/parts/ipc/test/node/ipc.cp.integrationTest.ts
@@ -11,10 +11,10 @@ import { Client } from '../../node/ipc.cp.js';
 import { ITestService, TestServiceClient } from './testService.js';
 import { FileAccess } from '../../../../common/network.js';
 
-function createClient(): Client {
+function createClient(env?: Record<string, string>): Client {
 	return new Client(FileAccess.asFileUri('bootstrap-fork').fsPath, {
 		serverName: 'TestServer',
-		env: { VSCODE_ESM_ENTRYPOINT: 'vs/base/parts/ipc/test/node/testApp', verbose: true }
+		env: { VSCODE_ESM_ENTRYPOINT: 'vs/base/parts/ipc/test/node/testApp', verbose: true, ...env }
 	});
 }
 
@@ -73,5 +73,17 @@ suite('IPC, Child Process', function () {
 	test('rejected call does not cause an unhandled rejection', async () => {
 		await assert.rejects(channel.call('unknown'), /command not found: unknown/);
 		await timeout(0);
+	});
+
+	test('deferred cancellation does not cause unhandled rejections', async () => {
+		client.dispose();
+		client = createClient({ VSCODE_IPC_TEST_DEFERRED_CANCELLATION: 'true' });
+		channel = client.getChannel('test');
+		const onDidProcessExit = Event.toPromise(Event.once(client.onDidProcessExit));
+		const result = channel.call('start');
+
+		const { code } = await onDidProcessExit;
+		await assert.rejects(result, /Canceled/);
+		assert.strictEqual(code, 0);
 	});
 });

--- a/src/vs/base/parts/ipc/test/node/testApp.ts
+++ b/src/vs/base/parts/ipc/test/node/testApp.ts
@@ -28,7 +28,7 @@ async function runDeferredCancellationTest(): Promise<void> {
 }
 
 if (process.env['VSCODE_IPC_TEST_DEFERRED_CANCELLATION']) {
-	runDeferredCancellationTest();
+	runDeferredCancellationTest().catch(() => process.exit(1));
 } else {
 	const server = new Server('test');
 	const service = new TestService();

--- a/src/vs/base/parts/ipc/test/node/testApp.ts
+++ b/src/vs/base/parts/ipc/test/node/testApp.ts
@@ -3,9 +3,34 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { timeout } from '../../../../common/async.js';
+import { CancellationTokenSource } from '../../../../common/cancellation.js';
+import { Event } from '../../../../common/event.js';
+import { ChannelClient } from '../../common/ipc.js';
 import { Server } from '../../node/ipc.cp.js';
 import { TestChannel, TestService } from './testService.js';
 
-const server = new Server('test');
-const service = new TestService();
-server.registerChannel('test', new TestChannel(service));
+async function runDeferredCancellationTest(): Promise<void> {
+	const unhandledRejections: unknown[] = [];
+	process.on('unhandledRejection', reason => unhandledRejections.push(reason));
+
+	const client = new ChannelClient({ onMessage: Event.None, send: () => { } });
+	const cancellationTokenSource = new CancellationTokenSource();
+	const result = client.getChannel('test').call('call', undefined, cancellationTokenSource.token);
+	cancellationTokenSource.cancel();
+	await result.catch(() => { });
+
+	const listener = client.getChannel('test').listen('event')(() => { });
+	listener.dispose();
+	await timeout(0);
+
+	process.exit(unhandledRejections.length);
+}
+
+if (process.env['VSCODE_IPC_TEST_DEFERRED_CANCELLATION']) {
+	runDeferredCancellationTest();
+} else {
+	const server = new Server('test');
+	const service = new TestService();
+	server.registerChannel('test', new TestChannel(service));
+}


### PR DESCRIPTION
Fixes unhandled Canceled promise rejections when IPC calls or event subscriptions are canceled before ChannelClient receives initialization. Caller-visible cancellation remains unchanged; only the internal deferred continuation handles the expected cancellation.

## Verification
- npm run transpile-client
- .\scripts\test.bat --run src/vs/base/parts/ipc/test/common/ipc.test.ts (24 passing)
- .\scripts\test-integration.bat --run src/vs/base/parts/ipc/test/node/ipc.cp.integrationTest.ts (6 passing)
- Focused regression failed before the fix with two unhandled rejections and passes afterward.