### PR TITLE
agent host: keep the idle timeout guard for the full websocket session

### DIFF
--- a/cli/src/commands/agent_host.rs
+++ b/cli/src/commands/agent_host.rs
@@ -388,13 +388,18 @@ async fn run_supervisor(mut ctx: CommandContext, mut args: AgentHostArgs) -> Res
 		// running sidecar -- never `ensure_supervisor_running`, which
 		// could spawn or reuse an unrelated supervisor -- so we build an
 		// already-resolved `SharedActiveAgentHost` from the sidecar's own
-		// published identity. Because that identity points back at our
-		// own loopback listener (`AgentHostSidecar::serve`, below), a
-		// legacy client proxied this way is accepted through the very
-		// same accept loop that already holds an `--idle-timeout`
-		// activity guard for its connection's whole lifetime, so a
-		// connected legacy tunnel client keeps counting as activity and
-		// cannot make the supervisor time itself out from under it.
+		// published identity.
+		//
+		// Each relayed socket carries its own `--idle-timeout` activity
+		// guard, attached to the transport so it survives the WebSocket
+		// upgrade (see `idle_timeout::GuardedStream`). The inner dial the
+		// gateway makes back into our own listener is not enough on its
+		// own: a client still waiting to send its selection, or one whose
+		// selection resolves to a *different* endpoint (another live
+		// registry entry, or a freshly spawned dedicated host), never
+		// reaches our accept loop at all, so without this guard an
+		// actively proxied tunnel client could not stop us timing out from
+		// under it.
 		let active_agent_host = ready_active_agent_host(sidecar.active_agent_host());
 		let launcher_paths = ctx.paths.clone();
 		let gateway_user_data_path = user_data_path.clone();
@@ -403,16 +408,21 @@ async fn run_supervisor(mut ctx: CommandContext, mut args: AgentHostArgs) -> Res
 			ctx.log,
 			"Routing dev-tunnel-hosted agent-host port through the protocol-v6 selection gateway"
 		);
+		let tunnel_activity = sidecar.activity_tracker();
 		tokio::spawn(async move {
 			while let Some(socket) = tunnel_port.recv().await {
 				let log = tunnel_log.clone();
 				let active_agent_host = active_agent_host.clone();
 				let launcher_paths = launcher_paths.clone();
 				let user_data_path = gateway_user_data_path.clone();
+				let rw = idle_timeout::GuardedStream::new(
+					socket.into_rw(),
+					tunnel_activity.as_ref().map(|a| a.client_connected()),
+				);
 				tokio::spawn(async move {
 					serve_agent_host_tunnel_connection(
 						log,
-						socket.into_rw(),
+						rw,
 						active_agent_host,
 						launcher_paths,
 						user_data_path,

--- a/cli/src/tunnels/agent_host.rs
+++ b/cli/src/tunnels/agent_host.rs
@@ -1204,13 +1204,17 @@ impl AgentHostSidecar {
 					};
 					let mgr = self.manager.clone();
 					let token = self.public_token.clone();
-					// Held for the connection task's whole lifetime so
+					// Attached to the stream (not held by this task) so
 					// `--idle-timeout` bookkeeping (when enabled) sees
-					// exactly one Connected/Disconnected pair per
-					// accepted connection.
-					let activity_guard = self.activity.as_ref().map(|a| a.client_connected());
+					// exactly one Connected/Disconnected pair spanning
+					// the connection's *whole* life, including after a
+					// WebSocket upgrade hands the transport off. See
+					// `idle_timeout::GuardedStream`.
+					let stream = idle_timeout::GuardedStream::new(
+						stream,
+						self.activity.as_ref().map(|a| a.client_connected()),
+					);
 					tokio::spawn(async move {
-						let _activity_guard = activity_guard;
 						let io = TokioIo::new(stream);
 						let svc = service_fn(move |req| {
 							let mgr = mgr.clone();
@@ -1238,10 +1242,14 @@ impl AgentHostSidecar {
 		RW: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 	{
 		debug!(self.log, "Serving tunnel agent host connection");
-		// Held for this connection's whole lifetime, same as the local
-		// accept loop in `serve`, so a tunnel-relayed client also counts
-		// as activity for `--idle-timeout` bookkeeping.
-		let _activity_guard = self.activity.as_ref().map(|a| a.client_connected());
+		// Attached to the stream, same as the local accept loop in
+		// `serve`, so a tunnel-relayed client also counts as activity for
+		// `--idle-timeout` bookkeeping for as long as it stays connected
+		// -- including after a WebSocket upgrade.
+		let rw = idle_timeout::GuardedStream::new(
+			rw,
+			self.activity.as_ref().map(|a| a.client_connected()),
+		);
 		let mgr = self.manager.clone();
 		let svc = service_fn(move |req| {
 			let mgr = mgr.clone();
@@ -2418,6 +2426,115 @@ mod tests {
 
 		opener.open(ShutdownSignal::CtrlC);
 		serve_task.await.unwrap().unwrap();
+	}
+
+	/// Regression test for the ~5-minute agent host recycle: the
+	/// `--idle-timeout` activity guard must span a connection's *whole*
+	/// life, including after it upgrades to a WebSocket.
+	///
+	/// `serve_connection_with_upgrades` resolves as soon as the upgrade is
+	/// handed off, so a guard held by the task awaiting it reported a
+	/// disconnect within milliseconds of a WebSocket starting. The idle
+	/// timer then saw zero clients, armed, and 300s later killed a
+	/// supervisor that was actively serving that WebSocket -- taking the
+	/// agent host server process tree (and any in-flight turn) with it.
+	/// Mirrors `AgentHostSidecar::serve`'s accept loop, including its use
+	/// of `idle_timeout::GuardedStream`.
+	#[tokio::test]
+	async fn activity_guard_spans_whole_websocket_session_not_just_the_upgrade() {
+		let (tracker, mut activity_rx) = idle_timeout::new_activity_channel();
+		let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = listener.local_addr().unwrap();
+
+		tokio::spawn(async move {
+			loop {
+				let (stream, _) = listener.accept().await.unwrap();
+				let stream =
+					idle_timeout::GuardedStream::new(stream, Some(tracker.client_connected()));
+				tokio::spawn(async move {
+					let io = TokioIo::new(stream);
+					let svc = service_fn(move |mut req: Request<Incoming>| async move {
+						let key = req
+							.headers()
+							.get("sec-websocket-key")
+							.map(|k| {
+								tokio_tungstenite::tungstenite::handshake::derive_accept_key(
+									k.as_bytes(),
+								)
+							})
+							.unwrap();
+						tokio::spawn(async move {
+							if let Ok(upgraded) = hyper::upgrade::on(&mut req).await {
+								let mut ws = WebSocketStream::from_raw_socket(
+									TokioIo::new(upgraded),
+									Role::Server,
+									None,
+								)
+								.await;
+								while let Some(Ok(m)) = ws.next().await {
+									if m.is_text() {
+										let _ = ws.send(m).await;
+									}
+								}
+							}
+						});
+						Ok::<_, Infallible>(
+							Response::builder()
+								.status(101)
+								.header("connection", "Upgrade")
+								.header("upgrade", "websocket")
+								.header("sec-websocket-accept", key)
+								.body(empty_body())
+								.unwrap(),
+						)
+					});
+					let _ = ServerBuilder::new(TokioExecutor::new())
+						.serve_connection_with_upgrades(io, svc)
+						.await;
+				});
+			}
+		});
+
+		let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+		let (mut client_ws, _) = tokio_tungstenite::client_async("ws://localhost/", stream)
+			.await
+			.expect("ws upgrade should succeed");
+
+		assert_eq!(
+			activity_rx.recv().await,
+			Some(idle_timeout::ActivityEvent::Connected)
+		);
+
+		// Prove the WebSocket is genuinely alive and carrying traffic.
+		client_ws
+			.send(Message::Text("still here".into()))
+			.await
+			.unwrap();
+		match client_ws.next().await {
+			Some(Ok(Message::Text(t))) => assert_eq!(t.as_str(), "still here"),
+			other => panic!("expected echo, got {other:?}"),
+		}
+
+		// A bounded wait is used only to prove no disconnect is reported
+		// while the session is demonstrably in use; it is not a timing
+		// dependency, since the pre-fix disconnect arrived immediately on
+		// upgrade (long before this point) and is already queued.
+		let premature = tokio::time::timeout(Duration::from_millis(500), activity_rx.recv()).await;
+		assert!(
+			premature.is_err(),
+			"no activity event may be reported while the websocket is still open, got {premature:?}"
+		);
+
+		// Closing the connection must still report the disconnect, so the
+		// idle timer can arm once the client is genuinely gone.
+		drop(client_ws);
+		let disconnected = tokio::time::timeout(Duration::from_secs(2), activity_rx.recv())
+			.await
+			.expect("did not observe a Disconnected activity event in time");
+		assert_eq!(
+			disconnected,
+			Some(idle_timeout::ActivityEvent::Disconnected)
+		);
 	}
 
 	#[tokio::test]

--- a/cli/src/tunnels/agent_host.rs
+++ b/cli/src/tunnels/agent_host.rs
@@ -1176,6 +1176,20 @@ impl AgentHostSidecar {
 		}
 	}
 
+	/// Returns a cloned handle for reporting client activity to
+	/// `--idle-timeout` bookkeeping, or `None` when idle-timeout is
+	/// disabled.
+	///
+	/// Callers serving connections this sidecar did not accept itself (the
+	/// dev-tunnel-hosted port in `run_supervisor`, which is handed sockets
+	/// by the tunnel relay rather than by [`Self::serve`]'s accept loop)
+	/// must report each connection and attach the resulting guard to that
+	/// connection's transport with [`idle_timeout::GuardedStream`], so the
+	/// client counts as activity for as long as it stays connected.
+	pub fn activity_tracker(&self) -> Option<idle_timeout::ActivityTracker> {
+		self.activity.clone()
+	}
+
 	/// Returns the wrapped manager, e.g. so callers can pre-fetch the latest
 	/// release, run an update loop, or directly serve tunnel-relayed
 	/// connections that bypass the public connection token.
@@ -3023,6 +3037,30 @@ mod tests {
 		port
 	}
 
+	/// Like [`spawn_fake_target_endpoint`], but keeps echoing for as long
+	/// as the client stays connected instead of closing after one message.
+	/// Needed when a test must distinguish "the proxied session is still
+	/// live" from "the target hung up".
+	async fn spawn_persistent_fake_target_endpoint() -> u16 {
+		let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let port = listener.local_addr().unwrap().port();
+		tokio::spawn(async move {
+			loop {
+				let (stream, _) = listener.accept().await.unwrap();
+				tokio::spawn(async move {
+					if let Ok(mut ws) = tokio_tungstenite::accept_async(stream).await {
+						while let Some(Ok(msg)) = ws.next().await {
+							if msg.is_text() && ws.send(msg).await.is_err() {
+								break;
+							}
+						}
+					}
+				});
+			}
+		});
+		port
+	}
+
 	/// Drives a full client-side selection session against an in-process
 	/// [`run_gateway_session`] over an in-memory duplex pipe, returning the
 	/// client's WebSocket end after the initial inventory message (parsed
@@ -3502,5 +3540,113 @@ mod tests {
 		let endpoints = inventory["endpoints"].as_array().unwrap();
 		assert_eq!(endpoints.len(), 1);
 		assert_eq!(endpoints[0]["instanceId"], "instance-direct-tunnel");
+	}
+
+	/// The dev-tunnel-hosted port in `run_supervisor` is handed sockets by
+	/// the tunnel relay, so they never pass through
+	/// `AgentHostSidecar::serve`'s accept loop and get no guard from it.
+	/// The gateway's inner dial back into our own listener does not cover
+	/// this either: a client still deciding what to select, or one whose
+	/// selection resolves to a *different* endpoint (as here), never
+	/// reaches that accept loop, so the supervisor owning the tunnel would
+	/// see zero clients and could time itself out while actively proxying.
+	///
+	/// Drives the real router (`serve_agent_host_tunnel_connection`) over a
+	/// guarded transport, exactly as `run_supervisor` now wires it up.
+	#[tokio::test]
+	async fn tunnel_hosted_gateway_connection_counts_as_activity_for_its_whole_session() {
+		let dir = tempfile::tempdir().unwrap();
+		let user_data_path = dir.path().join("user-data");
+		let launcher_paths = LauncherPaths::new_without_replacements(dir.path().to_path_buf());
+		let (tracker, mut activity_rx) = idle_timeout::new_activity_channel();
+
+		// A live endpoint that is *not* this supervisor, so a selection
+		// resolving to it never dials our own listener.
+		let target_port = spawn_persistent_fake_target_endpoint().await;
+		let entry = make_tcp_endpoint("instance-other-host", target_port, "");
+		agent_host_registry::publish_agent_host_endpoint(
+			&log::Logger::test(),
+			&user_data_path,
+			&entry,
+		)
+		.unwrap();
+
+		let active_agent_host = crate::tunnels::control_server::ready_active_agent_host(
+			crate::commands::agent_host::ActiveAgentHost {
+				pid: 0,
+				host: Some("127.0.0.1".to_string()),
+				port: 1,
+				token: None,
+			},
+		);
+
+		let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+		let server_io =
+			idle_timeout::GuardedStream::new(server_io, Some(tracker.client_connected()));
+		tokio::spawn(async move {
+			serve_agent_host_tunnel_connection(
+				log::Logger::test(),
+				server_io,
+				active_agent_host,
+				launcher_paths,
+				user_data_path,
+				false,
+			)
+			.await;
+		});
+
+		let (mut client_ws, _resp) = tokio_tungstenite::client_async(
+			format!("ws://localhost{AGENT_HOST_GATEWAY_SELECT_PATH}"),
+			client_io,
+		)
+		.await
+		.expect("gateway select upgrade should succeed");
+
+		assert_eq!(
+			activity_rx.recv().await,
+			Some(idle_timeout::ActivityEvent::Connected)
+		);
+
+		match client_ws.next().await {
+			Some(Ok(Message::Text(_))) => {}
+			other => panic!("expected inventory message, got {other:?}"),
+		}
+
+		// Select the *other* endpoint and exchange a frame through the
+		// proxy, proving the session is live and served entirely by this
+		// tunnel connection without any inner dial back into our listener.
+		client_ws
+			.send(Message::Text(
+				r#"{"instanceId":"instance-other-host"}"#.into(),
+			))
+			.await
+			.unwrap();
+		match client_ws.next().await {
+			Some(Ok(Message::Text(t))) => {
+				let ack: serde_json::Value = serde_json::from_str(&t).unwrap();
+				assert_eq!(ack["ok"], true);
+			}
+			other => panic!("expected selection ack, got {other:?}"),
+		}
+		client_ws.send(Message::Text("ping".into())).await.unwrap();
+		match client_ws.next().await {
+			Some(Ok(Message::Text(t))) => assert_eq!(t.as_str(), "ping"),
+			other => panic!("expected proxied echo, got {other:?}"),
+		}
+
+		let premature = tokio::time::timeout(Duration::from_millis(500), activity_rx.recv()).await;
+		assert!(
+			premature.is_err(),
+			"a proxied tunnel client must count as activity for its whole session, got {premature:?}"
+		);
+
+		drop(client_ws);
+		let disconnected = tokio::time::timeout(Duration::from_secs(2), activity_rx.recv())
+			.await
+			.expect("did not observe a Disconnected activity event in time");
+		assert_eq!(
+			disconnected,
+			Some(idle_timeout::ActivityEvent::Disconnected)
+		);
 	}
 }

--- a/cli/src/tunnels/idle_timeout.rs
+++ b/cli/src/tunnels/idle_timeout.rs
@@ -18,8 +18,10 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::mpsc;
 
 /// One client-connection lifecycle event, as reported by an
@@ -75,6 +77,75 @@ impl Drop for ClientGuard {
 pub fn new_activity_channel() -> (ActivityTracker, mpsc::UnboundedReceiver<ActivityEvent>) {
 	let (tx, rx) = mpsc::unbounded_channel();
 	(ActivityTracker { tx }, rx)
+}
+
+/// Wraps an accepted connection's transport so its [`ClientGuard`] lives
+/// exactly as long as that transport does.
+///
+/// The guard is deliberately attached to the *stream* rather than held by
+/// the task awaiting `serve_connection_with_upgrades`. That future
+/// resolves as soon as an HTTP connection is upgraded — it hands the
+/// transport off to `hyper::upgrade::on` and returns — so a guard held by
+/// that task reports a disconnect the instant a WebSocket *starts*,
+/// making a long-lived, actively-used connection invisible to the idle
+/// timer. Since the resulting `hyper::upgrade::Upgraded` still owns this
+/// wrapper, keeping the guard here means it survives the whole WebSocket
+/// session and drops only when the transport is finally dropped.
+///
+/// `guard` is an `Option` so callers can wrap unconditionally, keeping a
+/// single concrete stream type whether or not idle-timeout is enabled.
+pub struct GuardedStream<S> {
+	inner: S,
+	_guard: Option<ClientGuard>,
+}
+
+impl<S> GuardedStream<S> {
+	pub fn new(inner: S, guard: Option<ClientGuard>) -> Self {
+		Self {
+			inner,
+			_guard: guard,
+		}
+	}
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for GuardedStream<S> {
+	fn poll_read(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buf: &mut ReadBuf<'_>,
+	) -> Poll<std::io::Result<()>> {
+		Pin::new(&mut self.inner).poll_read(cx, buf)
+	}
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for GuardedStream<S> {
+	fn poll_write(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buf: &[u8],
+	) -> Poll<std::io::Result<usize>> {
+		Pin::new(&mut self.inner).poll_write(cx, buf)
+	}
+
+	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+		Pin::new(&mut self.inner).poll_flush(cx)
+	}
+
+	fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+		Pin::new(&mut self.inner).poll_shutdown(cx)
+	}
+
+	fn poll_write_vectored(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		bufs: &[std::io::IoSlice<'_>],
+	) -> Poll<std::io::Result<usize>> {
+		Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+	}
+
+	fn is_write_vectored(&self) -> bool {
+		self.inner.is_write_vectored()
+	}
 }
 
 /// Injectable timer seam so [`wait_for_idle_timeout`] can be driven


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/pull/330743

agent host: keep the idle timeout guard for the full websocket session

The `--idle-timeout` activity guard was released when a connection upgraded to a WebSocket, not
when the client disconnected. `serve_connection_with_upgrades` completes as soon as it hands the
transport to `hyper::upgrade::on`, so the task that held the guard ended a few milliseconds after
a WebSocket started. The idle timer then counted zero clients, armed, and 300 seconds later
stopped a supervisor that was still serving that client. The shutdown calls `kill_tree`, which
also stopped the agent host server and its child processes, so in-flight turns were lost.

Remote hosts showed this as a continuous restart loop. Agent host logs from one report contain 10
process starts in 50 minutes, each 297-299 seconds after its tunnel connection was established,
with no graceful shutdown message and a tool completion as the last line written. Connection
lifetime did not change with traffic: connections that carried 200 and 7,866 messages both ended
at approximately 305 seconds, and local (non-tunnel) connections in the same logs stayed up for
more than 2,900 seconds.

- Adds `idle_timeout::GuardedStream`, which holds the `ClientGuard` in the connection transport
  instead of the task that serves the connection. `hyper::upgrade::Upgraded` keeps the wrapped
  stream, so the guard now lives until the socket closes.
- Uses the wrapper in `AgentHostSidecar::serve` and in `serve_tunnel_connection`, so local and
  tunnel-relayed clients both report activity for their full connection.
- Takes an `Option<ClientGuard>` so callers wrap unconditionally and keep one stream type whether
  or not the idle timeout is enabled.
- Adds a regression test that upgrades a real WebSocket, exchanges a message, and makes sure that
  no disconnect is reported while the session is open and that the disconnect is still reported
  when the socket closes. The existing activity test used a bare TCP connection and could not
  find this problem.

(Commit message generated by Copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

