### PR TITLE
Execute a client tool the SDK replays from the transcript

### DIFF
--- a/src/vs/platform/agentHost/common/agent.ts
+++ b/src/vs/platform/agentHost/common/agent.ts
@@ -726,6 +726,7 @@ export interface IAgentModelInfo {
 export type AgentSignal =
 	| IAgentActionSignal
 	| IAgentToolPendingConfirmationSignal
+	| IAgentClientToolInvokedSignal
 	| IAgentSubagentStartedSignal
 	| IAgentSubagentResumedSignal
 	| IAgentSubagentCompletedSignal
@@ -797,6 +798,30 @@ export interface IAgentToolPendingConfirmationSignal {
 	 * action would land on the parent session, where there is no
 	 * matching `ChatToolCallStart`.
 	 */
+	readonly parentToolCallId?: string;
+}
+
+/**
+ * The runtime invoked a client-provided tool and is awaiting its result.
+ *
+ * Kept as a non-action signal because the host must decide whether the call
+ * needs driving: a normally streamed tool call already has protocol state and
+ * a client executing it, but a call replayed from the transcript (an SDK
+ * resume finishing a `tool_use` that never received its result) streams
+ * nothing, so the host must synthesize the start/ready pair the stream would
+ * have produced or no client will ever execute it.
+ */
+export interface IAgentClientToolInvokedSignal {
+	readonly kind: 'client_tool_invoked';
+	/** Target chat channel URI the tool call belongs to. */
+	readonly chat: URI;
+	/** SDK `tool_use_id` of the invocation. */
+	readonly toolCallId: string;
+	/** Unprefixed client tool name. */
+	readonly toolName: string;
+	/** JSON-serialized tool input. */
+	readonly toolInput: string;
+	/** See {@link IAgentToolPendingConfirmationSignal.parentToolCallId}. */
 	readonly parentToolCallId?: string;
 }
 

--- a/src/vs/platform/agentHost/node/agentSideEffects.ts
+++ b/src/vs/platform/agentHost/node/agentSideEffects.ts
@@ -21,7 +21,7 @@ import type { SessionMode } from '../common/agentHostSchema.js';
 import { AgentHostClientType } from '../common/agentHostClientInfo.js';
 import { AgentHostLaunchKind, createUnknownAgentHostClientTelemetryContext, type IAgentHostClientTelemetryContext } from '../common/agentHostTelemetry.js';
 import { readAgentModelByokIdentifier } from '../common/agentModelByokMeta.js';
-import { AgentSession, AgentSignal, IAgent, IAgentChatContext, IAgentToolPendingConfirmationSignal } from '../common/agent.js';
+import { AgentSession, AgentSignal, IAgent, IAgentChatContext, IAgentClientToolInvokedSignal, IAgentToolPendingConfirmationSignal } from '../common/agent.js';
 import { readToolCallMeta, toToolCallMeta } from '../common/meta/agentToolCallMeta.js';
 
 import { ITelemetryService } from '../../telemetry/common/telemetry.js';
@@ -29,7 +29,7 @@ import { ISessionDatabase, ISessionDataService } from '../common/sessionDataServ
 import { SessionConfigKey } from '../common/sessionConfigKeys.js';
 import { resolveChatAttachment } from '../common/state/chatAttachmentContext.js';
 import { buildOpenSessionLinkForChatResource } from '../common/openSessionLink.js';
-import { SessionInputRequestKind, ToolCallContributorKind, type AgentInfo, type Customization, type SessionActiveClient, type SessionInputRequest } from '../common/state/protocol/state.js';
+import { SessionInputRequestKind, ToolCallConfirmationReason, ToolCallContributorKind, type AgentInfo, type Customization, type SessionActiveClient, type SessionInputRequest } from '../common/state/protocol/state.js';
 import { ActionType, isChatAction, StateAction, type ChatAction, type ChatToolCallCompleteAction } from '../common/state/sessionActions.js';
 import {
 	buildSubagentChatUri,
@@ -832,6 +832,43 @@ export class AgentSideEffects extends Disposable {
 	}
 
 	/**
+	 * The runtime invoked a client tool whose call never streamed — an SDK
+	 * resume replaying a transcript-dangling `tool_use` emits no assistant
+	 * events, so no client execution was ever requested and the runtime would
+	 * wait forever. Synthesize the start/ready pair the stream would have
+	 * produced; a call that did stream already has protocol state and is left
+	 * alone.
+	 */
+	private _handleClientToolInvoked(signal: IAgentClientToolInvokedSignal, sessionKey: ProtocolURI, turnId: string): void {
+		if (this._findToolCall(sessionKey, turnId, signal.toolCallId)) {
+			return;
+		}
+		const sessionUri = parseRequiredSessionUriFromChatUri(sessionKey);
+		const owner = this._stateManager.getSessionState(sessionUri)?.activeClients.find(client => client.tools.some(tool => tool.name === signal.toolName));
+		if (!owner) {
+			this._logService.warn(`[AgentSideEffects] No active client provides replayed tool ${signal.toolName}; cannot execute ${signal.toolCallId}`);
+			return;
+		}
+		this._logService.info(`[AgentSideEffects] Requesting client execution for replayed tool call ${signal.toolCallId} (${signal.toolName})`);
+		this._stateManager.dispatchServerAction(sessionKey, {
+			type: ActionType.ChatToolCallStart,
+			turnId,
+			toolCallId: signal.toolCallId,
+			toolName: signal.toolName,
+			displayName: signal.toolName,
+			contributor: { kind: ToolCallContributorKind.Client, clientId: owner.clientId },
+		});
+		this._stateManager.dispatchServerAction(sessionKey, {
+			type: ActionType.ChatToolCallReady,
+			turnId,
+			toolCallId: signal.toolCallId,
+			invocationMessage: signal.toolName,
+			toolInput: signal.toolInput,
+			confirmed: ToolCallConfirmationReason.NotNeeded,
+		});
+	}
+
+	/**
 	 * Dispatches a signal to a resolved chat, preserving top-level turn identity or remapping cross-channel subagent actions.
 	 */
 	private _dispatchActionForSession(signal: AgentSignal, sessionKey: ProtocolURI, turnId: string, turnIdRouting: AgentSignalTurnIdRouting, agent?: IAgent): void {
@@ -841,6 +878,10 @@ export class AgentSideEffects extends Disposable {
 					this._logService.error('[AgentSideEffects] _handleToolReady failed', err);
 				});
 			}
+			return;
+		}
+		if (signal.kind === 'client_tool_invoked') {
+			this._handleClientToolInvoked(signal, sessionKey, turnId);
 			return;
 		}
 		if (signal.kind !== 'action') {

--- a/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeAgentSession.ts
@@ -749,7 +749,7 @@ export class ClaudeAgentSession extends Disposable {
 		resource: URI,
 		serverToolHost: IAgentServerToolHost | undefined,
 	): Promise<{ mcpServers: Record<string, McpSdkServerConfigWithInstance> | undefined; allowedTools: readonly string[] | undefined }> {
-		const clientServers = await buildClientMcpServers(this.toolDiff, this._pendingClientToolCalls, this._sdkService);
+		const clientServers = await buildClientMcpServers(this.toolDiff, (id, name, args) => this._awaitClientToolResult(id, name, args), this._sdkService);
 		const serverToolServer = serverToolHost
 			? await buildServerToolMcpServer(serverToolHost, resource.toString(), this._sdkService)
 			: undefined;
@@ -1159,6 +1159,23 @@ export class ClaudeAgentSession extends Disposable {
 	 * `ChatToolCallComplete` envelope, so SDK-owned tool completions land
 	 * here too and must NOT throw.
 	 */
+	/**
+	 * Park the SDK's client-tool invocation until the workbench echoes its
+	 * result. `registerAndFire` collects a buffered result without firing;
+	 * otherwise the fired signal lets the host start execution when the call
+	 * never streamed (an SDK resume replaying a transcript-dangling
+	 * `tool_use`, which the stream mapper never sees).
+	 */
+	private _awaitClientToolResult(toolUseId: string, toolName: string, args: unknown): Promise<CallToolResult> {
+		return this._pendingClientToolCalls.registerAndFire(toolUseId, () => this._onDidSessionProgress.fire({
+			kind: 'client_tool_invoked',
+			chat: this._chatChannelUri,
+			toolCallId: toolUseId,
+			toolName,
+			toolInput: JSON.stringify(args ?? {}),
+		}));
+	}
+
 	completeClientToolCall(toolCallId: string, result: ToolCallResult): boolean {
 		const converted = convertToolCallResult(result, toolCallId);
 		return this._pendingClientToolCalls.respond(toolCallId, converted);

--- a/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
+++ b/src/vs/platform/agentHost/node/claude/claudeSdkOptions.ts
@@ -12,7 +12,6 @@ import { rgDiskPath } from '../../../../base/node/ripgrep.js';
 import { AiAgentEnvValue, AiAgentEnvVar } from '../../../chat/common/aiAgentEnv.js';
 import { ClaudePermissionMode } from '../../common/claudeSessionConfigKeys.js';
 import { resolveClaudeEffort } from '../../common/claudeModelConfig.js';
-import { PendingRequestRegistry } from '../../common/pendingRequestRegistry.js';
 import type { ModelSelection } from '../../common/state/protocol/state.js';
 import { IClaudeAgentSdkService } from './claudeAgentSdkService.js';
 import { buildClientToolMcpServer } from './clientTools/claudeClientToolMcpServer.js';
@@ -180,14 +179,14 @@ export async function buildOptions(
  */
 export async function buildClientMcpServers(
 	toolDiff: SessionClientToolsDiff,
-	registry: PendingRequestRegistry<CallToolResult>,
+	awaitResult: (toolUseId: string, toolName: string, args: unknown) => Promise<CallToolResult>,
 	sdkService: IClaudeAgentSdkService,
 ): Promise<Record<string, McpSdkServerConfigWithInstance> | undefined> {
 	const tools = toolDiff.consume();
 	if (tools.length === 0) {
 		return undefined;
 	}
-	const server = await buildClientToolMcpServer(tools, id => registry.register(id), sdkService);
+	const server = await buildClientToolMcpServer(tools, awaitResult, sdkService);
 	return { client: server };
 }
 

--- a/src/vs/platform/agentHost/node/claude/clientTools/claudeClientToolMcpServer.ts
+++ b/src/vs/platform/agentHost/node/claude/clientTools/claudeClientToolMcpServer.ts
@@ -35,14 +35,14 @@ const TOOL_USE_ID_META_KEY = 'claudecode/toolUseId';
  */
 export async function buildClientToolMcpServer(
 	snapshot: readonly ToolDefinition[],
-	awaitResult: (toolUseId: string) => Promise<CallToolResult>,
+	awaitResult: (toolUseId: string, toolName: string, args: unknown) => Promise<CallToolResult>,
 	sdk: IClaudeAgentSdkService
 ): Promise<McpSdkServerConfigWithInstance> {
 	const tools = await Promise.all(snapshot.map(def => sdk.tool(
 		def.name,
 		def.description ?? '',
 		jsonSchemaToZodRawShape(def.inputSchema),
-		async (_args, extra) => {
+		async (args, extra) => {
 			const toolUseId = extractToolUseId(extra);
 			if (toolUseId === undefined) {
 				return {
@@ -53,7 +53,7 @@ export async function buildClientToolMcpServer(
 					isError: true,
 				};
 			}
-			return awaitResult(toolUseId);
+			return awaitResult(toolUseId, def.name, args);
 		}
 	)));
 	return sdk.createSdkMcpServer({ name: CLAUDE_CLIENT_MCP_SERVER_NAME, tools });

--- a/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentSideEffects.test.ts
@@ -1042,6 +1042,32 @@ suite('AgentSideEffects', () => {
 			});
 		});
 
+		test('client_tool_invoked synthesizes execution for a replayed call and leaves a streamed one alone', () => {
+			setupSession();
+			disposables.add(sideEffects.registerProgressListener(agent));
+			stateManager.dispatchClientAction(sessionUri.toString(), {
+				type: ActionType.SessionActiveClientSet,
+				activeClient: { clientId: 'client-A', tools: [{ name: 'openBrowserPage', inputSchema: { type: 'object' } }] },
+			}, { clientId: 'test', clientSeq: 1 });
+			startTurn('turn-1');
+
+			// Replay: the call is absent from turn state, so the host must create it.
+			agent.fireProgress({ kind: 'client_tool_invoked', chat: URI.parse(defaultChatUri), toolCallId: 'tu_replay', toolName: 'openBrowserPage', toolInput: '{"url":"http://x/"}' });
+			// Streamed: the call already has state and must not be duplicated.
+			agent.fireProgress({ kind: 'client_tool_invoked', chat: URI.parse(defaultChatUri), toolCallId: 'tu_replay', toolName: 'openBrowserPage', toolInput: '{"url":"http://x/"}' });
+
+			const parts = stateManager.getChatState(defaultChatUri)?.activeTurn?.responseParts ?? [];
+			const toolCalls = parts.filter(part => part.kind === ResponsePartKind.ToolCall).map(part => part.toolCall);
+			const inputNeeded = stateManager.getSessionState(sessionUri.toString())?.inputNeeded ?? [];
+			assert.deepStrictEqual({
+				toolCalls: toolCalls.map(tc => ({ id: tc.toolCallId, status: tc.status, contributor: tc.contributor, toolInput: tc.status === ToolCallStatus.Running ? tc.toolInput : undefined })),
+				executionRequests: inputNeeded.filter(request => request.kind === SessionInputRequestKind.ToolClientExecution).map(request => ({ toolCallId: request.toolCall.toolCallId, clientId: request.clientId })),
+			}, {
+				toolCalls: [{ id: 'tu_replay', status: ToolCallStatus.Running, contributor: { kind: ToolCallContributorKind.Client, clientId: 'client-A' }, toolInput: '{"url":"http://x/"}' }],
+				executionRequests: [{ toolCallId: 'tu_replay', clientId: 'client-A' }],
+			});
+		});
+
 		test('does not duplicate a Codex provider-owned failure when sendMessage resolves', async () => {
 			setupSession();
 			disposables.add(sideEffects.registerProgressListener(agent));

--- a/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/claudeAgent.test.ts
@@ -641,6 +641,10 @@ class FakeClaudeAgentSdkService implements IClaudeAgentSdkService {
 		readonly description: string;
 		readonly inputSchema: Record<string, any>;
 	}> = [];
+	readonly toolHandlers: Array<{
+		readonly name: string;
+		readonly handler: (args: any, extra: unknown) => Promise<CallToolResult>;
+	}> = [];
 	readonly createSdkMcpServerCalls: Array<{
 		readonly name: string;
 		readonly toolNames: readonly string[];
@@ -650,9 +654,10 @@ class FakeClaudeAgentSdkService implements IClaudeAgentSdkService {
 		name: string,
 		description: string,
 		inputSchema: Record<string, any>,
-		_handler: (args: any, extra: unknown) => Promise<CallToolResult>,
+		handler: (args: any, extra: unknown) => Promise<CallToolResult>,
 	): Promise<SdkMcpToolDefinition<any>> {
 		this.toolCalls.push({ name, description, inputSchema });
+		this.toolHandlers.push({ name, handler });
 		return { name } as unknown as SdkMcpToolDefinition<any>;
 	}
 
@@ -5455,6 +5460,38 @@ suite('ClaudeAgent', () => {
 		}, {
 			startupCount: 1,
 			builtToolNames: ['echo'],
+		});
+	});
+
+	test('an SDK client tool invocation fires client_tool_invoked and resolves on completion', async () => {
+		const { agent, sdk } = createTestContext(disposables);
+		await agent.authenticate(GITHUB_COPILOT_PROTECTED_RESOURCE.resource, 'tok');
+		const created = await createSession(agent, { workingDirectories: [URI.file('/work')] });
+		const sessionId = created.sdkSessionId;
+		getOrCreateActiveClient(agent, defaultChatUri(created.session), 'client-1').tools = [{ name: 'echo', inputSchema: { type: 'object' } }];
+		sdk.nextQueryMessages = [makeSystemInitMessage(sessionId), makeResultSuccess(sessionId)];
+		await agent.chats.sendMessage(defaultChatUri(created.session), 'go', undefined, undefined, 'turn-1', undefined, undefined, chatContext(defaultChatUri(created.session)));
+
+		const session = agent.getSessionForTesting(created.session)!;
+		const signals: AgentSignal[] = [];
+		disposables.add(session.onDidSessionProgress(s => signals.push(s)));
+
+		// A replayed invocation streams nothing, so the fired signal is the only
+		// way the host learns a client must execute this call.
+		const handler = sdk.toolHandlers.find(t => t.name === 'echo')!.handler;
+		const callPromise = handler({ msg: 'hi' }, { _meta: { 'claudecode/toolUseId': 'tu_replay' } });
+		const fired = signals.filter(s => s.kind === 'client_tool_invoked');
+		session.completeClientToolCall('tu_replay', { success: true, pastTenseMessage: 'ok', content: [{ type: ToolResultContentType.Text, text: 'done' }] });
+
+		assert.deepStrictEqual({ fired, resolvedContent: (await callPromise).content }, {
+			fired: [{
+				kind: 'client_tool_invoked',
+				chat: session.chatChannelUri,
+				toolCallId: 'tu_replay',
+				toolName: 'echo',
+				toolInput: '{"msg":"hi"}',
+			}],
+			resolvedContent: [{ type: 'text', text: 'done' }],
 		});
 	});
 

--- a/src/vs/platform/agentHost/test/node/clientTools/claudeClientToolMcpServer.test.ts
+++ b/src/vs/platform/agentHost/test/node/clientTools/claudeClientToolMcpServer.test.ts
@@ -76,6 +76,17 @@ suite('claudeClientToolMcpServer / buildClientToolMcpServer', () => {
 		assert.deepStrictEqual(await callPromise, expected);
 	});
 
+	test('handler forwards the tool name and args to awaitResult', async () => {
+		const { sdk, recorded } = makeSdk();
+		const calls: Array<{ id: string; name: string; args: unknown }> = [];
+		await buildClientToolMcpServer([tool({ name: 'echo' })], async (id, name, args) => {
+			calls.push({ id, name, args });
+			return { content: [] };
+		}, sdk);
+		await recorded[0]!.handler({ msg: 'hi' }, { _meta: { 'claudecode/toolUseId': 'tu_1' } });
+		assert.deepStrictEqual(calls, [{ id: 'tu_1', name: 'echo', args: { msg: 'hi' } }]);
+	});
+
 	test('handler returns an error result when SDK omits the tool_use_id meta field', async () => {
 		const { sdk, recorded } = makeSdk();
 		const registry = new PendingRequestRegistry<CallToolResult>();


### PR DESCRIPTION
Companion to microsoft/vscode#330730; together they close the remaining ways a client tool call wedges a Claude session in a remote window (microsoft/vscode#322990).

## The failure

Cancel a turn while a client tool call is pending and the transcript keeps an assistant `tool_use` with no `tool_result`. On the next message the SDK resumes and **replays** that call: it invokes the in-process MCP tool directly, without re-streaming the assistant message. The stream mapper — the sole trigger for client-tool execution — sees nothing, so no execution is ever requested. The SDK waits forever, emitting only `tool_progress` heartbeats, and the UI sits at "Considering".

Worse, the dangling `tool_use` is durable: **every** subsequent resume replays it, so the session is permanently wedged. Observed live on 1.133.0:

```
transcript tail:  assistant  tool_use: mcp__client__openBrowserPage (toolu_01Kx9CBY…)   ← no result
21:22:49  chat/turnStarted            ← resume
          (no stream events, no toolCallStart — nothing on the wire)
21:23:10  tool_progress toolu_01Kx9CBY…-heartbeat-0
21:23:39  tool_progress …-heartbeat-1   (forever)
```

## The fix

The MCP handler already receives everything needed — the tool name, the args, and the `tool_use_id`. It now parks via `PendingRequestRegistry.registerAndFire`, firing a `client_tool_invoked` signal. The host checks turn state:

- The call streamed normally → it has protocol state and a client already executing it → the signal is a no-op.
- The call is absent (replay) → the host synthesizes the `ChatToolCallStart` / `ChatToolCallReady` pair the stream would have produced, which drives the existing `ToolClientExecution` request path, so the client executes it like any other call.

`registerAndFire` collects a result buffered before registration *without* firing, so this composes with #330730's eager-execution buffering rather than re-triggering execution.

The synthesis is deliberately host-side (`agentSideEffects`), where turn state lives — the reducer appends blindly on `ChatToolCallStart`, so the session cannot safely emit unconditionally.

## Testing

- `an SDK client tool invocation fires client_tool_invoked and resolves on completion` — session-level, through the real MCP handler wiring.
- `client_tool_invoked synthesizes execution for a replayed call and leaves a streamed one alone` — host-level: the replayed call gains a `Running` tool call with the owning client's contributor and a `ToolClientExecution` request; a second signal for the same id does not duplicate state.
- `handler forwards the tool name and args to awaitResult` — factory-level.
- Suites: AgentSideEffects 220 passing, ClaudeAgent 266 passing / 3 failing (same 3 on an unmodified checkout — model catalog / credential tests, unrelated), buildClientToolMcpServer 6 passing.
- `npm run typecheck-client` clean.