### PR TITLE
agentHost: Fix server tool advertisement during restore

### DIFF
--- a/src/vs/platform/agentHost/node/agentService.ts
+++ b/src/vs/platform/agentHost/node/agentService.ts
@@ -3928,6 +3928,7 @@ export class AgentService extends Disposable implements IAgentService {
 			throw new ProtocolError(AHP_SESSION_NOT_FOUND, `Session was explicitly deleted: ${sessionStr}`);
 		}
 		this._stateManager.restoreSession(summary, mergedTurns, { draft: restoredDraft, defaultChatTitle });
+		this._serverToolHost.advertise(sessionStr);
 
 		// A freshly-adopted legacy session bridges its git checkpoints into the
 		// agent-host namespace once its turns are restored. Isolated so a failure

--- a/src/vs/platform/agentHost/node/shared/agentServerToolHost.ts
+++ b/src/vs/platform/agentHost/node/shared/agentServerToolHost.ts
@@ -136,6 +136,10 @@ export class AgentServerToolHost implements IAgentServerToolHost {
 	}
 
 	advertise(sessionUri: URI): void {
+		// Provider materialization can precede restore; AgentService advertises again once the session is registered.
+		if (!this._stateManager.getSessionState(sessionUri)) {
+			return;
+		}
 		this._stateManager.dispatchServerAction(sessionUri, {
 			type: ActionType.SessionServerToolsChanged,
 			tools: [...this.definitions],

--- a/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts
@@ -341,6 +341,15 @@ suite('AgentFeedbackServerTools', () => {
 			assert.deepStrictEqual(state?.serverTools, feedbackServerToolDefinitions);
 		});
 
+		test('advertise does not dispatch before the session is registered', () => {
+			const actionTypes: string[] = [];
+			disposables.add(manager.onDidEmitEnvelope(envelope => actionTypes.push(envelope.action.type)));
+
+			host.advertise(sessionResource);
+
+			assert.deepStrictEqual(actionTypes, []);
+		});
+
 		test('canRequireConfirmation reflects the owning group', () => {
 			assert.deepStrictEqual({
 				view: host.canRequireConfirmation(viewUnreviewedCommentsToolName),

--- a/src/vs/platform/agentHost/test/node/agentService.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentService.test.ts
@@ -5012,6 +5012,19 @@ suite('AgentService (node dispatcher)', () => {
 			assert.strictEqual(state!.turns[0].state, TurnState.Complete);
 		});
 
+		test('advertises server tools after restoring the session state', async () => {
+			service.registerProvider(copilotAgent);
+			await createAgentSession(copilotAgent);
+			const sessionResource = (await copilotAgent.listSessions())[0].session;
+
+			await service.restoreSession(sessionResource);
+
+			assert.strictEqual(
+				service.stateManager.getSessionState(sessionResource.toString())?.serverTools?.some(tool => tool.name === SessionServerToolName.ListSessions),
+				true,
+			);
+		});
+
 		test('re-attaches persisted turn usage on restore', async () => {
 			// Providers don't durably record token/credit usage (the Copilot
 			// SDK's `assistant.usage` event is explicitly ephemeral), so without


### PR DESCRIPTION
## Summary

- avoid dispatching server-tool advertisements before restored session state is registered
- advertise server tools immediately after AgentService restores authoritative session state
- add regression tests for both sides of the restore ordering

## Why

Provider materialization can advertise server tools while AgentService is still restoring a session. The state manager then receives `session/serverToolsChanged` for an unknown session and emits an orphan action envelope.

## Validation

- `npm run transpile-client`
- `./scripts/test.sh --run src/vs/platform/agentHost/test/node/agentFeedbackServerTools.test.ts --run src/vs/platform/agentHost/test/node/agentService.test.ts --grep advertise`
- `git diff --check`

(Written by Copilot)