### PR TITLE
Set default timeline display to gutter for all builds

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/promptTimeline/promptTimeline.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptTimeline/promptTimeline.contribution.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../../nls.js';
-import product from '../../../../../platform/product/common/product.js';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from '../../../../../platform/configuration/common/configurationRegistry.js';
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { ChatWidget } from '../widget/chatWidget.js';
@@ -36,8 +35,7 @@ configurationRegistry.registerConfiguration({
 				localize('sessions.chatTimeline.display.ruler', "Show an overview ruler beside the transcript scrollbar that fans into prompt pills on engagement."),
 				localize('sessions.chatTimeline.display.gutter', "Show a minimal handle in the transcript's left gutter that opens a list of prompts on hover."),
 			],
-			// Still being tried out, so it is only on by default outside stable.
-			default: product.quality !== 'stable' ? 'gutter' : 'off',
+			default: 'gutter',
 			description: localize('sessions.chatTimeline.display', "Controls how the prompt timeline is displayed next to the chat transcript in the Agents window."),
 			tags: ['experimental'],
 			experiment: { mode: 'startup' },


### PR DESCRIPTION
This pull request updates the default setting for the sessions timeline display to `gutter` for both Stable and Insiders builds. Previously, the default was `off` for Stable builds, while Insiders had it set to `gutter`. 

Changes made:
- Removed the product-quality condition that differentiated between Stable and Insiders builds.
- Deleted an unused import to clean up the code.
- Ensured that explicit user settings (`off`, `ruler`, or `gutter`) remain unchanged.

This change simplifies the configuration and ensures a consistent user experience across all builds. The update has been verified with `git diff --check`, and no tests were required for this configuration-only change.