### PR TITLE
agentHost: route runtime policy diagnostics through proxy

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -116,15 +116,41 @@ export async function getCopilotManagedSettingsDiagnostics(
 	host: string,
 	signal: AbortSignal,
 	timeoutMs = COPILOT_MANAGED_SETTINGS_QUERY_TIMEOUT_MS,
+	proxy: string | undefined = undefined,
 ): Promise<{ account?: string; resolved: ManagedSettingsResolvedData }> {
-	const result = await raceTimeout(runtimeSdk.getManagedSettings({
+	const request = invokeWithProxyEnvironment(proxy, () => runtimeSdk.getManagedSettings({
 		...(token ? { authInfo: { type: 'token', host, token } as const, token } : {}),
 		signal,
-	}), timeoutMs);
+	}));
+	const result = await raceTimeout(request, timeoutMs);
 	if (!result) {
 		throw new Error(`Copilot runtime managed-settings query exceeded ${timeoutMs / 1000} seconds while waiting for native MDM or GitHub policy resolution.`);
 	}
 	return result;
+}
+
+function invokeWithProxyEnvironment<T>(proxy: string | undefined, invoke: () => Promise<T>): Promise<T> {
+	if (!proxy) {
+		return invoke();
+	}
+	const previousValues = COPILOT_PROXY_SET_ENV_KEYS.map(key => process.env[key]);
+	for (const key of COPILOT_PROXY_SET_ENV_KEYS) {
+		process.env[key] = proxy;
+	}
+	try {
+		// The SDK snapshots process.env while constructing the native request.
+		return invoke();
+	} finally {
+		for (let index = 0; index < COPILOT_PROXY_SET_ENV_KEYS.length; index++) {
+			const key = COPILOT_PROXY_SET_ENV_KEYS[index];
+			const value = previousValues[index];
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
 }
 
 const RUNTIME_SLASH_COMMAND_COMPLETION_WAIT_MS = 300;
@@ -1148,12 +1174,16 @@ export class CopilotAgent extends Disposable implements IAgent {
 				throw new Error('Copilot runtime SDK does not expose getManagedSettings()');
 			}
 
+			stage = 'resolving the proxy';
+			const proxy = await this._resolveProxyForSdk();
 			stage = 'querying native MDM and GitHub managed settings';
 			return getCopilotManagedSettingsDiagnostics(
 				runtimeSdk,
 				this._githubToken,
 				this._gitHubEndpointService.getEnterpriseUri() ?? 'https://github.com',
 				AbortSignal.timeout(COPILOT_MANAGED_SETTINGS_DIAGNOSTICS_TIMEOUT_MS),
+				COPILOT_MANAGED_SETTINGS_QUERY_TIMEOUT_MS,
+				proxy,
 			);
 		})();
 		const result = await raceTimeout(diagnostics, COPILOT_MANAGED_SETTINGS_DIAGNOSTICS_TIMEOUT_MS);

--- a/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgent.test.ts
@@ -1577,24 +1577,43 @@ suite('CopilotAgent', () => {
 
 	test('queries managed settings with pre-resolved token authentication', async () => {
 		let receivedInput: { authInfo?: { type: 'token'; host: string; token: string }; token?: string; signal?: AbortSignal } | undefined;
+		let proxyEnvironment: Record<string, string | undefined> | undefined;
 		const runtimeSdk = {
 			getManagedSettings: async (input?: typeof receivedInput) => {
 				receivedInput = input;
+				proxyEnvironment = {
+					HTTP_PROXY: process.env['HTTP_PROXY'],
+					HTTPS_PROXY: process.env['HTTPS_PROXY'],
+				};
 				return { resolved: { source: 'none' as const, serverManaged: false, deviceManaged: false, clientManaged: false, failClosed: false, bypassPermissionsDisabled: false, managedKeys: [] } };
 			},
 		};
 		const signal = new AbortController().signal;
+		const before = {
+			HTTP_PROXY: process.env['HTTP_PROXY'],
+			HTTPS_PROXY: process.env['HTTPS_PROXY'],
+		};
 
-		await getCopilotManagedSettingsDiagnostics(runtimeSdk, 'token', 'https://github.example.com', signal);
+		await getCopilotManagedSettingsDiagnostics(runtimeSdk, 'token', 'https://github.example.com', signal, 3500, 'http://proxy.example.com:8080');
 
 		assert.deepStrictEqual({
 			authInfo: receivedInput?.authInfo,
 			token: receivedInput?.token,
 			signalForwarded: receivedInput?.signal === signal,
+			proxyEnvironment,
+			environmentRestored: {
+				HTTP_PROXY: process.env['HTTP_PROXY'],
+				HTTPS_PROXY: process.env['HTTPS_PROXY'],
+			},
 		}, {
 			authInfo: { type: 'token', host: 'https://github.example.com', token: 'token' },
 			token: 'token',
 			signalForwarded: true,
+			proxyEnvironment: {
+				HTTP_PROXY: 'http://proxy.example.com:8080',
+				HTTPS_PROXY: 'http://proxy.example.com:8080',
+			},
+			environmentRestored: before,
 		});
 	});
 


### PR DESCRIPTION
## Summary

Routes the account-scoped Copilot runtime managed-settings diagnostic through the same resolved proxy used by Copilot SDK sessions.

The runtime SDK reads `HTTP_PROXY` / `HTTPS_PROXY` from `process.env` while constructing the native request, so the diagnostic temporarily exposes the resolved proxy for that invocation and immediately restores the prior environment.

Split from #330711 to keep the mock policy server PR product-neutral.

## Testing

- Focused `CopilotAgent` unit tests pass
- ESLint, client transpilation, and pre-commit hygiene pass
- E2E: authenticated **Developer: Policy Diagnostics** reached the local mock through `http.proxy`, returned HTTP 200, and resolved the managed model to `Auto`