### PR TITLE
Modern UI tabs: reserve close-button column so it doesn't overlay filename (fix #329605)

### DIFF
--- a/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
+++ b/src/vs/workbench/contrib/styleOverrides/browser/media/tabs.css
@@ -157,12 +157,13 @@
 	padding: 0 var(--vscode-spacing-size80) 0 var(--vscode-spacing-size60) !important;
 }
 
-.modern-ui-tabs .part.editor .tabs-container > .tab.dirty:not(.sticky-compact):not(.tab-actions-left):not(.close-action-off.dirty-border-top),
+/* Reserve the overlay column so close/pin/dirty never covers the filename (https://github.com/microsoft/vscode/issues/329605) */
+.modern-ui-tabs .part.editor .tabs-container > .tab:not(.sticky-compact):not(.tab-actions-left):not(.close-action-off),
 .modern-ui-tabs .part.editor .tabs-container > .tab.sticky:not(.sticky-compact):not(.pinned-action-off):not(.tab-actions-left) {
 	padding-right: var(--vscode-spacing-size280) !important;
 }
 
-.modern-ui-tabs .part.editor .tabs-container > .tab.dirty.tab-actions-left:not(.sticky-compact),
+.modern-ui-tabs .part.editor .tabs-container > .tab.tab-actions-left:not(.sticky-compact):not(.close-action-off),
 .modern-ui-tabs .part.editor .tabs-container > .tab.sticky.tab-actions-left:not(.sticky-compact):not(.pinned-action-off) {
 	padding-left: var(--vscode-spacing-size240) !important;
 	padding-right: var(--vscode-spacing-size80) !important;
@@ -304,11 +305,7 @@
 	display: none;
 }
 
-/*
- * Overlay tab actions on the label instead of reserving a trailing/leading
- * column. The action surface inherits the tab background while revealed so
- * label text and icons beneath it do not compete with the action glyph.
- */
+/* Overlay tab actions in the reserved trailing/leading column */
 .modern-ui-tabs.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab > .tab-actions {
 	position: absolute;
 	z-index: 7;


### PR DESCRIPTION
Fixes #329605

## Problem

In Modern UI, the tab action overlay (close/pin/dirty control) is absolutely positioned on top of the tab label, so clicking a filename near the trailing edge of a tab hits the close control and closes the tab unexpectedly.

## Fix

Reserve the overlay column as padding instead of letting the control overlap the label:

- Every tab that can show a trailing close/pin/dirty control now reserves `28px` on the right (the same inset dirty/sticky tabs already used before).
- Left-actions tabs reserve `24px` on the left, symmetrically.
- The absolutely positioned control then renders in the reserved column and never covers the filename hit target.

Tabs with close actions off — and dirty tabs that only show the dirty top border — have no overlay to reserve, so they keep the compact `close-action-off` padding.

## Verification

Tested locally with a Code OSS build (Playwright-driven): with the fix, hovering a tab reveals the close control inside the reserved column, and clicking the filename region no longer triggers tab closure; hit-testing the label area returns the label element, not the close action.

## Test plan

- [ ] Modern UI on, `workbench.editor.tabSizing: fit` (default): hover tab, click filename — tab stays open, editor focuses
- [ ] Clicking the revealed close control still closes the tab
- [ ] `tabSizing: shrink` / `fixed`: no layout regressions
- [ ] `tabActionsLocation: left`: reserved column on the left, same behavior
- [ ] Close action off (`workbench.editor.tabActionCloseVisibility: off`): compact padding, no reserved column
- [ ] Dirty tab with dirty-border-top + actions off: compact padding
- [ ] Sticky/pinned tabs: pin control still works, no overlap