### PR TITLE
Remove up/down buttons from chat sticky header

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -133,7 +133,7 @@ export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat' | 'qui
 		content.push(localize('workbench.action.chat.nextUserPrompt', 'To navigate to the next user prompt in the conversation, invoke the Next User Prompt command{0}.', '<keybinding:workbench.action.chat.nextUserPrompt>'));
 		content.push(localize('workbench.action.chat.previousUserPrompt', 'To navigate to the previous user prompt in the conversation, invoke the Previous User Prompt command{0}.', '<keybinding:workbench.action.chat.previousUserPrompt>'));
 		if (stickyPromptHeaderShown) {
-			content.push(localize('chat.stickyPromptHeader', 'The prompt you have scrolled past is pinned to the top of the transcript. Activate its title to jump back to that prompt, or use the Go to Previous Prompt and Go to Next Prompt buttons beside it to move between prompts.'));
+			content.push(localize('chat.stickyPromptHeader', 'The prompt you have scrolled past is pinned to the top of the transcript. Activate its title to jump back to that prompt.'));
 		}
 		content.push(localize('workbench.action.chat.announceConfirmation', 'To focus pending chat confirmation dialogs, invoke the Focus Chat Confirmation Status command{0}.', '<keybinding:workbench.action.chat.focusConfirmation>'));
 		content.push(localize('chat.showHiddenTerminals', 'If there are any hidden chat terminals, you can view them by invoking the View Hidden Chat Terminals command{0}.', '<keybinding:workbench.action.terminal.chat.viewHiddenChatTerminals>'));

--- a/src/vs/workbench/contrib/chat/browser/promptTimeline/media/promptTimeline.css
+++ b/src/vs/workbench/contrib/chat/browser/promptTimeline/media/promptTimeline.css
@@ -108,7 +108,6 @@
 .prompt-timeline-sticky-band {
 	display: flex;
 	align-items: center;
-	gap: 6px;
 	flex: 1 1 auto;
 	min-width: 0;
 	height: 30px;
@@ -199,13 +198,6 @@
 	flex: 0 0 auto;
 	color: var(--vscode-descriptionForeground);
 	font-variant-numeric: tabular-nums;
-}
-
-/* Hosts the Previous/Next toolbar; the toolbar supplies its own theming and spacing. */
-.prompt-timeline-sticky-nav {
-	display: flex;
-	align-items: center;
-	flex: 0 0 auto;
 }
 
 .prompt-timeline-sticky-label-button:focus-visible {

--- a/src/vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineModel.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineModel.ts
@@ -489,26 +489,6 @@ export class PromptTimelineModel extends Disposable {
 		}
 	}
 
-	/**
-	 * Reveals the prompt `delta` positions away from the one the header names, aligned to the top of the
-	 * transcript like the rail and the label activation. The header then follows scroll tracking, hiding
-	 * once the target prompt is at the top.
-	 */
-	navigate(delta: number): void {
-		const prompts = this._prompts.get();
-		if (prompts.length === 0) {
-			return;
-		}
-		const id = this._activePromptId.get();
-		const current = id ? prompts.findIndex(p => p.requestId === id) : 0;
-		const base = current < 0 ? 0 : current;
-		const target = Math.max(0, Math.min(prompts.length - 1, base + delta));
-		if (target === base) {
-			return;
-		}
-		this.reveal(prompts[target].requestId);
-	}
-
 	/** The changed files for a tick's prompts, aggregated per file (for the hover card / drill-down). */
 	getRequestFiles(tick: PromptTick): readonly PromptFileDiff[] {
 		const byPath = new Map<string, PromptFileDiff>();

--- a/src/vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineStickyHeader.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineStickyHeader.ts
@@ -4,25 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { $, addDisposableListener, append, EventType } from '../../../../../base/browser/dom.js';
-import { Action } from '../../../../../base/common/actions.js';
-import { Codicon } from '../../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { localize } from '../../../../../nls.js';
 import { IAccessibilityService } from '../../../../../platform/accessibility/common/accessibility.js';
-import { WorkbenchToolBar } from '../../../../../platform/actions/browser/toolbar.js';
-import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import './media/promptTimeline.css';
-
-const PREVIOUS_ACTION_ID = 'promptTimeline.sticky.previous';
-const NEXT_ACTION_ID = 'promptTimeline.sticky.next';
 
 /**
  * A flat, opaque header pinned to the top of the chat transcript, modelled on the editor's sticky
- * scroll: it names the prompt currently scrolled off the top and offers previous/next actions to
- * step through prompts. Activating the label reveals the prompt it names. Purely
- * presentational — the owner drives its content and visibility.
+ * scroll: it names the prompt currently scrolled off the top. Activating the label reveals the
+ * prompt it names. Purely presentational — the owner drives its content and visibility.
  */
 export class PromptTimelineStickyHeader extends Disposable {
 
@@ -30,8 +21,6 @@ export class PromptTimelineStickyHeader extends Disposable {
 	private readonly _labelButton: HTMLButtonElement;
 	private readonly _label: HTMLElement;
 	private readonly _count: HTMLElement;
-	private readonly _previousAction: Action;
-	private readonly _nextAction: Action;
 
 	/** The line element currently naming the pinned prompt (siblings are transient roll animations). */
 	private _labelLine: HTMLElement;
@@ -46,15 +35,10 @@ export class PromptTimelineStickyHeader extends Disposable {
 	/** Fired when the label is clicked or activated by keyboard. */
 	readonly onDidActivate: Event<void> = this._onDidActivate.event;
 
-	private readonly _onDidNavigate = this._register(new Emitter<number>());
-	/** Fired with `-1` (previous prompt) or `+1` (next prompt) when a navigation action is run. */
-	readonly onDidNavigate: Event<number> = this._onDidNavigate.event;
-
 	get domNode(): HTMLElement { return this._domNode; }
 
 	constructor(
 		container: HTMLElement,
-		@IInstantiationService instantiationService: IInstantiationService,
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 	) {
 		super();
@@ -71,15 +55,6 @@ export class PromptTimelineStickyHeader extends Disposable {
 		// A native <button> already activates on click and on Enter/Space, so no manual key handling.
 		this._register(addDisposableListener(this._labelButton, EventType.CLICK, () => this._onDidActivate.fire()));
 
-		// Previous/Next use a standard toolbar for theming, keyboard behaviour and action lifecycle.
-		this._previousAction = this._register(new Action(PREVIOUS_ACTION_ID, localize('promptTimeline.previousPrompt', "Go to Previous Prompt"), ThemeIcon.asClassName(Codicon.chevronUp), true, async () => this._onDidNavigate.fire(-1)));
-		this._nextAction = this._register(new Action(NEXT_ACTION_ID, localize('promptTimeline.nextPrompt', "Go to Next Prompt"), ThemeIcon.asClassName(Codicon.chevronDown), true, async () => this._onDidNavigate.fire(1)));
-		const toolbarContainer = append(band, $('.prompt-timeline-sticky-nav'));
-		const toolbar = this._register(instantiationService.createInstance(WorkbenchToolBar, toolbarContainer, {
-			ariaLabel: localize('promptTimeline.stickyNavAriaLabel', "Prompt navigation"),
-		}));
-		toolbar.setActions([this._previousAction, this._nextAction]);
-
 		// Start hidden and out of the tab order until a prompt is pinned (see setVisible).
 		this._setVisible(false);
 	}
@@ -90,10 +65,6 @@ export class PromptTimelineStickyHeader extends Disposable {
 		this._count.textContent = localize('promptTimeline.stickyCount', "{0}/{1}", index, total);
 		this._labelButton.title = label;
 		this._labelButton.setAttribute('aria-label', localize('promptTimeline.stickyLabel', "Go to prompt {0} of {1}: {2}", index, total, label));
-
-		// The ends of the prompt list have nowhere to step to, so disable the matching action.
-		this._previousAction.enabled = index > 1;
-		this._nextAction.enabled = index < total;
 
 		if (label !== this._currentLabel || index !== this._lastIndex) {
 			// Step direction from the previous prompt drives which way the label rolls.

--- a/src/vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineWidgetContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineWidgetContrib.ts
@@ -45,7 +45,7 @@ export function observePromptTimelineHostWidth(
 
 /**
  * Whether the sticky prompt header is mounted for a widget. Shared with the accessibility help so it
- * only describes the header (and its navigation buttons) on widgets that actually get one.
+ * only describes the header on widgets that actually get one.
  */
 export function isStickyPromptHeaderShown(widget: IChatWidget, configurationService: IConfigurationService): boolean {
 	return supportsPromptTimeline(widget)
@@ -185,13 +185,11 @@ export class PromptTimelineWidgetContrib extends Disposable implements IChatWidg
 	/**
 	 * Mounts the flat sticky header that pins the current prompt to the top of the transcript. It shows
 	 * only once that prompt's row has scrolled above the viewport (via {@link PromptTimelineModel.activePinned}).
-	 * Its previous/next toolbar actions step through prompts; activating the label jumps straight to the
-	 * prompt it names (scrolling it to the top of the transcript).
+	 * Activating the label jumps straight to the prompt it names (scrolling it to the top of the transcript).
 	 */
 	private _createStickyHeader(model: PromptTimelineModel): void {
 		const sticky = this._enablement.add(this.instantiationService.createInstance(PromptTimelineStickyHeader, this.widget.domNode));
 		this._enablement.add(sticky.onDidActivate(() => model.revealActivePrompt()));
-		this._enablement.add(sticky.onDidNavigate(delta => model.navigate(delta)));
 		this._enablement.add(autorun(reader => {
 			// Drive the header from the unbucketed active prompt so the label and N/M position match
 			// the real prompt list (the rail's ticks are bucketed/capped and would misreport long chats).

--- a/src/vs/workbench/contrib/chat/test/browser/accessibility/chatAccessibilityHelp.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/accessibility/chatAccessibilityHelp.test.ts
@@ -84,17 +84,19 @@ suite('Chat Accessibility Help', () => {
 		const keybindingService = {
 			lookupKeybindings: () => [],
 		} as unknown as IKeybindingService;
-		const describesStickyHeader = (shown: boolean) =>
-			getAccessibilityHelpText('agentView', keybindingService, true, false, shown).includes('pinned to the top of the transcript');
+		const shownHelp = getAccessibilityHelpText('agentView', keybindingService, true, false, true);
+		const hiddenHelp = getAccessibilityHelpText('agentView', keybindingService, true, false, false);
 
 		assert.deepStrictEqual({
-			shown: describesStickyHeader(true),
-			notShown: describesStickyHeader(false),
+			shown: shownHelp.includes('pinned to the top of the transcript'),
+			notShown: hiddenHelp.includes('pinned to the top of the transcript'),
 			byDefault: getAccessibilityHelpText('agentView', keybindingService, true).includes('pinned to the top of the transcript'),
+			navigationButtons: shownHelp.includes('Go to Previous Prompt') || shownHelp.includes('Go to Next Prompt'),
 		}, {
 			shown: true,
 			notShown: false,
 			byDefault: false,
+			navigationButtons: false,
 		});
 	});
 


### PR DESCRIPTION
This pull request removes the up/down navigation buttons and toolbar from the sticky header of the chat sessions, as requested. Key changes include:

- **Removal of Navigation Controls**: The previous/next buttons and their associated toolbar have been eliminated from the sticky prompt header.
- **Code Cleanup**: Unused navigation events, model methods, and related CSS have been removed to streamline the codebase.
- **Accessibility Updates**: The chat accessibility help has been updated to reflect the changes in the UI.
- **Test Adjustments**: A shallow DOM regression test was removed, and the focus is now on ensuring the accessibility help remains accurate.

Validation steps confirmed that all relevant tests passed, and no unintended changes were made to the lockfile or generated files.