### PR TITLE
agentHost: add Copilot SKU telemetry context

### DIFF
--- a/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryReporter.ts
@@ -18,11 +18,13 @@ import type { ToolInvokedResult } from './agentHostToolCallTracker.js';
 import { multiplexProperties, type IAgentHostRestrictedTelemetry, type IAgentHostRestrictedTelemetryContext } from './agentHostRestrictedTelemetry.js';
 import type { AgentHostClientType } from '../common/agentHostClientInfo.js';
 import { AgentHostClientConnectionKind, AgentHostLaunchKind, AgentHostTransportKind, type IAgentHostClientTelemetryContext } from '../common/agentHostTelemetry.js';
+import { isAgentHostTelemetryService } from './agentHostTelemetryService.js';
 
 export type AgentHostUserMessageSentSource = 'direct' | 'queued';
 
 export interface IAgentHostExecutionModeChangedEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	isSubagentSession: boolean;
 	previousMode: SessionMode;
@@ -32,6 +34,7 @@ export interface IAgentHostExecutionModeChangedEvent {
 
 export type IAgentHostExecutionModeChangedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The raw Copilot entitlement SKU, when the session uses the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the mode change belongs to a subagent session.' };
 	previousMode: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The previous agent host execution mode.' };
@@ -43,6 +46,7 @@ export type IAgentHostExecutionModeChangedClassification = {
 
 export interface IAgentHostUserMessageSentEvent {
 	provider: string;
+	copilotSku?: string;
 	hostLaunchKind: AgentHostLaunchKind;
 	initiatorClientId: string | undefined;
 	initiatorClientType: AgentHostClientType;
@@ -60,6 +64,7 @@ export interface IAgentHostUserMessageSentEvent {
 
 export type IAgentHostUserMessageSentClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The raw Copilot entitlement SKU, when the message uses the Copilot provider and account discovery returned one.' };
 	hostLaunchKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the agent host process was launched by the VS Code main process or VS Code CLI.' };
 	initiatorClientId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The opaque AHP client identifier that initiated the user message.' };
 	initiatorClientType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The type of AHP client that initiated the user message.' };
@@ -139,6 +144,7 @@ export type AgentHostTurnFailureStage = 'validation' | 'workingDirectory' | 'mod
 
 export interface IAgentHostTurnCompletedEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	chatSessionId: string;
 	isSubagentSession: boolean;
@@ -159,6 +165,7 @@ export interface IAgentHostTurnCompletedEvent {
 
 export type IAgentHostTurnCompletedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The raw Copilot entitlement SKU, when the turn uses the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The chat identifier within the agent host session.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the turn belongs to a subagent session.' };
@@ -181,6 +188,7 @@ export type IAgentHostTurnCompletedClassification = {
 
 export interface IAgentHostTurnFailedEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	chatSessionId: string;
 	isSubagentSession: boolean;
@@ -197,6 +205,7 @@ export interface IAgentHostTurnFailedEvent {
 
 export type IAgentHostTurnFailedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the failed agent host turn.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The raw Copilot entitlement SKU, when the failed turn uses the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The chat identifier within the agent host session.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the failed turn belongs to a subagent session.' };
@@ -308,6 +317,7 @@ function normalizeTurnActivityKind(activityKind: string): AgentHostTurnActivityT
 
 export interface IAgentHostTurnHungEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	chatSessionId: string;
 	isSubagentSession: boolean;
@@ -329,6 +339,7 @@ export interface IAgentHostTurnHungEvent {
 
 export type IAgentHostTurnHungClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the hung agent host turn.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The raw Copilot entitlement SKU, when the hung turn uses the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The chat identifier within the agent host session.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the hung turn belongs to a subagent session.' };
@@ -371,6 +382,7 @@ export interface IAgentHostTurnHungReport {
 
 export interface IAgentHostHungTurnCompletedEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	chatSessionId: string;
 	isSubagentSession: boolean;
@@ -384,6 +396,7 @@ export interface IAgentHostHungTurnCompletedEvent {
 
 export type IAgentHostHungTurnCompletedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the recovered agent host turn.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The raw Copilot entitlement SKU, when the recovered turn uses the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The chat identifier within the agent host session.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the recovered turn belongs to a subagent session.' };
@@ -432,6 +445,7 @@ export interface IAgentHostAskQuestionsToolInvokedEvent {
 	recommendedSelectedCount: number;
 	duration: number;
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	isSubagentSession: boolean;
 }
@@ -446,6 +460,7 @@ export type IAgentHostAskQuestionsToolInvokedClassification = {
 	recommendedSelectedCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The number of questions where the user selected the recommended option' };
 	duration: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'The total time in milliseconds to complete all questions' };
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The raw Copilot entitlement SKU, when the questions use the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the questions belong to a subagent session.' };
 	owner: 'digitarald';
@@ -469,6 +484,7 @@ type AgentHostToolCallResponseType = 'success' | 'cancelled' | 'failed';
 
 export interface IAgentHostToolCallDetailsEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	isSubagentSession: boolean;
 	conversationId: string;
@@ -488,6 +504,7 @@ export interface IAgentHostToolCallDetailsEvent {
 
 export type IAgentHostToolCallDetailsClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The raw Copilot entitlement SKU, when the tool calls use the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the tool-call aggregate belongs to a subagent session.' };
 	conversationId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the current chat conversation.' };
@@ -543,6 +560,7 @@ type AgentHostToolApprovalConfirmKind = 'userAction' | 'setting' | 'confirmation
 
 export interface IAgentHostToolApprovalEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	isSubagentSession: boolean;
 	chatSessionId: string;
@@ -561,6 +579,7 @@ export interface IAgentHostToolApprovalEvent {
 
 export type IAgentHostToolApprovalClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider handling the agent host session.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The raw Copilot entitlement SKU, when the tool approval uses the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host session identifier.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'Whether the tool approval belongs to a subagent session.' };
 	chatSessionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The ID of the chat session that the tool was used within, if applicable.' };
@@ -637,6 +656,7 @@ export interface IAgentHostRepoInfoReport {
 
 export interface IAgentHostToolCallStalledEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	isSubagentSession: boolean;
 	blockerKind: SessionInputRequestKind.ToolConfirmation | SessionInputRequestKind.ToolClientExecution | SessionInputRequestKind.ToolAuthentication;
@@ -647,6 +667,7 @@ export interface IAgentHostToolCallStalledEvent {
 
 export type IAgentHostToolCallStalledClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the stalled agent host tool call.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The raw Copilot entitlement SKU, when the stalled tool call uses the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the stalled tool call belongs to a subagent session.' };
 	blockerKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the tool call is waiting for confirmation or client execution.' };
@@ -668,6 +689,7 @@ export interface IAgentHostToolCallStalledReport {
 
 export interface IAgentHostStalledToolCallCompletedEvent {
 	provider: string;
+	copilotSku?: string;
 	agentSessionId: string;
 	isSubagentSession: boolean;
 	blockerKind: SessionInputRequestKind.ToolConfirmation | SessionInputRequestKind.ToolClientExecution | SessionInputRequestKind.ToolAuthentication;
@@ -680,6 +702,7 @@ export interface IAgentHostStalledToolCallCompletedEvent {
 
 export type IAgentHostStalledToolCallCompletedClassification = {
 	provider: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The provider handling the completed agent host tool call.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The raw Copilot entitlement SKU, when the completed tool call uses the Copilot provider and account discovery returned one.' };
 	agentSessionId: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'The agent host session identifier.' };
 	isSubagentSession: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the completed tool call belongs to a subagent session.' };
 	blockerKind: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Whether the tool call had stalled waiting for confirmation or client execution.' };
@@ -717,6 +740,17 @@ export class AgentHostTelemetryReporter {
 
 	constructor(private readonly _telemetryService: ITelemetryService) { }
 
+	private _getCopilotSku(provider: string): string | undefined {
+		return provider === 'copilot' && isAgentHostTelemetryService(this._telemetryService)
+			? this._telemetryService.copilotSku
+			: undefined;
+	}
+
+	private _getCopilotSkuProperty(provider: string): { readonly copilotSku?: string } {
+		const copilotSku = this._getCopilotSku(provider);
+		return copilotSku ? { copilotSku } : {};
+	}
+
 	/** The restricted GH/MSFT telemetry surface, present when the agent-host telemetry service is wired. */
 	private get _restricted(): IAgentHostRestrictedTelemetry | undefined {
 		const ts = this._telemetryService as Partial<IAgentHostRestrictedTelemetry>;
@@ -726,6 +760,7 @@ export class AgentHostTelemetryReporter {
 	executionModeChanged(provider: string, session: string, previousMode: SessionMode, newMode: SessionMode, turnCount: number): void {
 		this._telemetryService.publicLog2<IAgentHostExecutionModeChangedEvent, IAgentHostExecutionModeChangedClassification>('agentHost.executionModeChanged', {
 			provider,
+			...this._getCopilotSkuProperty(provider),
 			agentSessionId: AgentSession.id(session),
 			isSubagentSession: isSubagentSession(session),
 			previousMode,
@@ -740,6 +775,7 @@ export class AgentHostTelemetryReporter {
 		const sessionUri = isAhpChatChannel(session) ? parseRequiredSessionUriFromChatUri(session) : session;
 		this._telemetryService.publicLog2<IAgentHostUserMessageSentEvent, IAgentHostUserMessageSentClassification>('agentHost.userMessageSent', {
 			provider,
+			...this._getCopilotSkuProperty(provider),
 			hostLaunchKind: clientContext.hostLaunchKind,
 			initiatorClientId: clientId,
 			initiatorClientType: clientContext.clientType,
@@ -878,8 +914,10 @@ export class AgentHostTelemetryReporter {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
 		const conversationId = AgentSession.id(session);
 		const toolCounts = JSON.stringify(report.toolCounts);
+		const copilotSku = this._getCopilotSku(report.provider);
 		this._telemetryService.publicLog2<IAgentHostToolCallDetailsEvent, IAgentHostToolCallDetailsClassification>('toolCallDetails', {
 			provider: report.provider,
+			...(copilotSku ? { copilotSku } : {}),
 			agentSessionId: conversationId,
 			isSubagentSession: isSubagentSession(session),
 			conversationId,
@@ -907,6 +945,7 @@ export class AgentHostTelemetryReporter {
 			messageId: report.turnId,
 			initiatorClientType: report.clientType,
 			responseType: report.responseType,
+			...(copilotSku ? { copilotSku } : {}),
 			...(report.model ? { model: report.model } : {}),
 			toolCounts,
 			availableTools: JSON.stringify(report.availableTools),
@@ -931,6 +970,7 @@ export class AgentHostTelemetryReporter {
 		const agentSessionId = AgentSession.id(session);
 		this._telemetryService.publicLog2<IAgentHostToolApprovalEvent, IAgentHostToolApprovalClassification>('chat.toolApproval', {
 			provider: report.provider,
+			...this._getCopilotSkuProperty(report.provider),
 			agentSessionId,
 			isSubagentSession: isSubagentSession(session),
 			chatSessionId: agentSessionId,
@@ -1072,8 +1112,10 @@ export class AgentHostTelemetryReporter {
 		const chatSessionId = getTelemetryChatSessionId(report.session);
 		const isSubagent = isSubagentChatUri(report.session) || isSubagentSession(session);
 		const model = toTelemetryModel(report.model, report.modelTelemetryKind);
+		const copilotSku = this._getCopilotSku(report.provider);
 		this._telemetryService.publicLog2<IAgentHostTurnCompletedEvent, IAgentHostTurnCompletedClassification>('agentHost.turnCompleted', {
 			provider: report.provider,
+			...(copilotSku ? { copilotSku } : {}),
 			agentSessionId: AgentSession.id(session),
 			chatSessionId,
 			isSubagentSession: isSubagent,
@@ -1095,6 +1137,7 @@ export class AgentHostTelemetryReporter {
 			const { providerCallId, serviceRequestId } = readAgentErrorTelemetryMeta(report.failure.error);
 			this._telemetryService.publicLogError2<IAgentHostTurnFailedEvent, IAgentHostTurnFailedClassification>('agentHost.turnFailed', {
 				provider: report.provider,
+				...(copilotSku ? { copilotSku } : {}),
 				agentSessionId: AgentSession.id(session),
 				chatSessionId,
 				isSubagentSession: isSubagent,
@@ -1120,6 +1163,7 @@ export class AgentHostTelemetryReporter {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
 		this._telemetryService.publicLog2<IAgentHostTurnHungEvent, IAgentHostTurnHungClassification>('agentHost.turnHung', {
 			provider: report.provider,
+			...this._getCopilotSkuProperty(report.provider),
 			agentSessionId: AgentSession.id(session),
 			chatSessionId: getTelemetryChatSessionId(report.session),
 			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
@@ -1145,6 +1189,7 @@ export class AgentHostTelemetryReporter {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
 		this._telemetryService.publicLog2<IAgentHostHungTurnCompletedEvent, IAgentHostHungTurnCompletedClassification>('agentHost.hungTurnCompleted', {
 			provider: report.provider,
+			...this._getCopilotSkuProperty(report.provider),
 			agentSessionId: AgentSession.id(session),
 			chatSessionId: getTelemetryChatSessionId(report.session),
 			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
@@ -1171,6 +1216,7 @@ export class AgentHostTelemetryReporter {
 			toolCallId: report.toolCallId,
 			invocationTimeMs: report.invocationTimeMs,
 			provider: report.provider,
+			...this._getCopilotSkuProperty(report.provider),
 			resultSizeInCharacters: report.resultSizeInCharacters,
 			turnId: report.turnId,
 			model: toTelemetryModel(report.model, report.modelTelemetryKind),
@@ -1189,6 +1235,7 @@ export class AgentHostTelemetryReporter {
 			recommendedSelectedCount: report.recommendedSelectedCount,
 			duration: report.duration,
 			provider: report.provider,
+			...this._getCopilotSkuProperty(report.provider),
 			agentSessionId: AgentSession.id(session),
 			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
 		});
@@ -1198,6 +1245,7 @@ export class AgentHostTelemetryReporter {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
 		this._telemetryService.publicLog2<IAgentHostToolCallStalledEvent, IAgentHostToolCallStalledClassification>('agentHost.toolCallStalled', {
 			provider: report.provider,
+			...this._getCopilotSkuProperty(report.provider),
 			agentSessionId: AgentSession.id(session),
 			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
 			blockerKind: report.blockerKind,
@@ -1211,6 +1259,7 @@ export class AgentHostTelemetryReporter {
 		const session = isAhpChatChannel(report.session) ? parseRequiredSessionUriFromChatUri(report.session) : report.session;
 		this._telemetryService.publicLog2<IAgentHostStalledToolCallCompletedEvent, IAgentHostStalledToolCallCompletedClassification>('agentHost.stalledToolCallCompleted', {
 			provider: report.provider,
+			...this._getCopilotSkuProperty(report.provider),
 			agentSessionId: AgentSession.id(session),
 			isSubagentSession: isSubagentChatUri(report.session) || isSubagentSession(session),
 			blockerKind: report.blockerKind,

--- a/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
+++ b/src/vs/platform/agentHost/node/agentHostTelemetryService.ts
@@ -40,6 +40,8 @@ export interface IAgentHostTelemetryServiceOptions {
 }
 
 export interface IAgentHostTelemetryService extends ITelemetryService, IAgentHostRestrictedTelemetry {
+	readonly copilotSku: string | undefined;
+	setCopilotSku(copilotSku: string | undefined): void;
 	updateTelemetryLevel(telemetryLevel: TelemetryLevel): void;
 }
 
@@ -47,6 +49,7 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 	declare readonly _serviceBrand: undefined;
 
 	private _telemetryLevel = TelemetryLevel.USAGE;
+	private _copilotSku: string | undefined;
 
 	/**
 	 * Whether the current Copilot token opts into enhanced/restricted telemetry (`rt=1`). Defaults
@@ -78,6 +81,10 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 
 	get telemetryLevel(): TelemetryLevel {
 		return Math.min(this._delegate.telemetryLevel, this._telemetryLevel);
+	}
+
+	get copilotSku(): string | undefined {
+		return this._copilotSku;
 	}
 
 	get sendErrorTelemetry(): boolean {
@@ -197,6 +204,10 @@ export class AgentHostTelemetryService extends Disposable implements IAgentHostT
 
 	setCommonProperty(name: string, value: string | boolean): void {
 		this._delegate.setCommonProperty(name, value);
+	}
+
+	setCopilotSku(copilotSku: string | undefined): void {
+		this._copilotSku = copilotSku;
 	}
 
 	updateTelemetryLevel(telemetryLevel: TelemetryLevel): void {

--- a/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgent.ts
@@ -1309,6 +1309,9 @@ export class CopilotAgent extends Disposable implements IAgent {
 		this._logService.info(`[Copilot] Auth token ${token ? 'updated' : 'cleared'}`);
 		this._githubToken = token;
 		this._updateRestrictedTelemetry(token);
+		if (isAgentHostTelemetryService(this._telemetryService)) {
+			this._telemetryService.setCopilotSku(undefined);
+		}
 		if (!token) {
 			await this._requestClientRestart('GitHub authentication cleared');
 			void this._scheduleModelRefresh();
@@ -1335,6 +1338,7 @@ export class CopilotAgent extends Disposable implements IAgent {
 		} else {
 			await this._restartClientIfProxyChanged();
 		}
+		await this._resolveCopilotSku(token);
 		void this._scheduleModelRefresh();
 	}
 
@@ -1343,6 +1347,17 @@ export class CopilotAgent extends Disposable implements IAgent {
 			resource: this._gitHubEndpointService.getCopilotResource(),
 			reason: AuthRequiredReason.Expired,
 		}, undefined);
+	}
+
+	private async _resolveCopilotSku(githubToken: string): Promise<void> {
+		try {
+			const copilotSku = await this._copilotApiService.resolveCopilotSku?.(githubToken);
+			if (this._githubToken === githubToken && isAgentHostTelemetryService(this._telemetryService)) {
+				this._telemetryService.setCopilotSku(copilotSku);
+			}
+		} catch (err) {
+			this._logService.debug(`[Copilot] SKU resolution failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
 	}
 
 	async handleAuthenticationToken(params: AuthenticateParams): Promise<boolean> {

--- a/src/vs/platform/agentHost/node/shared/copilotApiService.ts
+++ b/src/vs/platform/agentHost/node/shared/copilotApiService.ts
@@ -96,6 +96,8 @@ interface ICachedClient {
 	readonly capiClient: CAPIClient;
 	readonly expiresAt: number;
 	readonly utilityModelIdsByFamily: Map<string, string>;
+	/** The raw Copilot entitlement SKU returned by `/copilot_internal/user`, when present. */
+	readonly copilotSku?: string;
 	/** GitHub login returned by `/copilot_internal/user`, when present. */
 	readonly login?: string;
 	/** The CAPI `endpoints.telemetry` base URL discovered for this token, if any. */
@@ -551,6 +553,9 @@ export interface ICopilotApiService {
 
 	/** Resolve the GitHub login cached from `/copilot_internal/user`. */
 	resolveUserLogin?(githubToken: string): Promise<string | undefined>;
+
+	/** Resolve the raw Copilot entitlement SKU cached from `/copilot_internal/user`. */
+	resolveCopilotSku?(githubToken: string): Promise<string | undefined>;
 }
 
 export class CopilotApiService implements ICopilotApiService {
@@ -918,6 +923,10 @@ export class CopilotApiService implements ICopilotApiService {
 		return (await this._getEntryForToken(githubToken)).login;
 	}
 
+	async resolveCopilotSku(githubToken: string): Promise<string | undefined> {
+		return (await this._getEntryForToken(githubToken)).copilotSku;
+	}
+
 	private _getEntryForToken(githubToken: string): Promise<ICachedClient> {
 		const nowSeconds = Date.now() / 1000;
 		const existing = this._clientsByToken.get(githubToken);
@@ -1015,6 +1024,7 @@ export class CopilotApiService implements ICopilotApiService {
 			capiClient,
 			expiresAt: Date.now() / 1000 + CAPI_CONTEXT_TTL_SECONDS,
 			utilityModelIdsByFamily: new Map(),
+			copilotSku: envelope.access_type_sku,
 			login: envelope.login,
 			telemetryEndpoint: envelope.endpoints?.telemetry,
 			apiEndpoint: envelope.endpoints?.api,

--- a/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
+++ b/src/vs/platform/agentHost/test/node/agentHostTelemetryReporter.test.ts
@@ -17,6 +17,7 @@ import { IAgentHostInternalTelemetryContext, IAgentHostRestrictedTelemetry, IAge
 import { AgentHostTelemetryReporter } from '../../node/agentHostTelemetryReporter.js';
 import { AgentHostClientType } from '../../common/agentHostClientInfo.js';
 import { ActionType } from '../../common/state/sessionActions.js';
+import { AgentHostTelemetryService } from '../../node/agentHostTelemetryService.js';
 
 interface IRestrictedCall {
 	eventName: string;
@@ -45,7 +46,9 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 	publicLog2(eventName: string, data?: ITelemetryData): void {
 		this.standardEvents.push({ eventName, data });
 	}
-	publicLogError2(): void { }
+	publicLogError2(eventName: string, data?: ITelemetryData): void {
+		this.standardEvents.push({ eventName, data });
+	}
 	setExperimentProperty(): void { }
 	setCommonProperty(): void { }
 
@@ -72,7 +75,7 @@ class TestRestrictedTelemetryService implements ITelemetryService, IAgentHostRes
 }
 
 suite('AgentHostTelemetryReporter', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
 
 	const session = 'agent-session://copilot/abc';
 	const tools: ToolDefinition[] = [{ name: 'grep' }, { name: 'edit' }];
@@ -160,7 +163,16 @@ suite('AgentHostTelemetryReporter', () => {
 
 	test('toolCallDetails emits standard and restricted aggregates whenever tools were available, and no-ops when none were', async () => {
 		const service = new TestRestrictedTelemetryService();
-		const reporter = new AgentHostTelemetryReporter(service);
+		const telemetryService = store.add(new AgentHostTelemetryService(service, service));
+		telemetryService.setCopilotSku('copilot_for_business_seat');
+		telemetryService.setRestrictedTelemetryEnabled(true);
+		telemetryService.setInternalTelemetryContext({
+			isInternal: true,
+			trackingId: undefined,
+			userName: undefined,
+			isVscodeTeamMember: false,
+		});
+		const reporter = new AgentHostTelemetryReporter(telemetryService);
 
 		await reporter.toolCallDetails({
 			provider: 'copilot', session, turnId: 'a1b2c3d4-0000-4000-8000-000000000000', clientType: AgentHostClientType.Unknown, model: 'gpt-x', responseType: 'success',
@@ -185,6 +197,7 @@ suite('AgentHostTelemetryReporter', () => {
 			eventName: 'toolCallDetails',
 			data: {
 				provider: 'copilot',
+				copilotSku: 'copilot_for_business_seat',
 				agentSessionId: AgentSession.id(session),
 				isSubagentSession: false,
 				conversationId: AgentSession.id(session),
@@ -205,6 +218,7 @@ suite('AgentHostTelemetryReporter', () => {
 			eventName: 'toolCallDetails',
 			data: {
 				provider: 'copilot',
+				copilotSku: 'copilot_for_business_seat',
 				agentSessionId: AgentSession.id(session),
 				isSubagentSession: false,
 				conversationId: AgentSession.id(session),
@@ -231,6 +245,7 @@ suite('AgentHostTelemetryReporter', () => {
 				messageId: 'a1b2c3d4-0000-4000-8000-000000000000',
 				initiatorClientType: 'editor_window',
 				responseType: 'success',
+				copilotSku: 'copilot_for_business_seat',
 				model: 'gpt-x',
 				toolCounts: JSON.stringify({}),
 				availableTools: JSON.stringify(['grep', 'edit']),
@@ -243,6 +258,7 @@ suite('AgentHostTelemetryReporter', () => {
 				messageId: 'a1b2c3d4-0000-4000-8000-000000000000',
 				initiatorClientType: 'agents_window',
 				responseType: 'cancelled',
+				copilotSku: 'copilot_for_business_seat',
 				model: 'gpt-x',
 				toolCounts: JSON.stringify({ grep: 2, edit: 1 }),
 				availableTools: JSON.stringify(['grep', 'edit']),
@@ -251,6 +267,45 @@ suite('AgentHostTelemetryReporter', () => {
 		assert.strictEqual(service.internalEvents.length, 2);
 		assert.strictEqual(service.internalEvents[0].eventName, 'toolCallDetailsInternal');
 		assert.strictEqual(service.internalEvents[1].eventName, 'toolCallDetailsInternal');
+	});
+
+	test('turn telemetry includes Copilot SKU only for the Copilot provider', () => {
+		const service = new TestRestrictedTelemetryService();
+		const telemetryService = store.add(new AgentHostTelemetryService(service, service));
+		telemetryService.setCopilotSku('copilot_for_business_seat');
+		const reporter = new AgentHostTelemetryReporter(telemetryService);
+		const common = {
+			session,
+			turnId: 'turn-1',
+			timeToFirstProgress: 10,
+			totalTime: 20,
+			result: 'error' as const,
+			model: 'gpt-x',
+			modelTelemetryKind: 'trusted' as const,
+			modelSelectionKind: 'explicit' as const,
+			permissionLevel: 'default',
+			interactionMode: 'interactive' as const,
+			failure: {
+				stage: 'provider' as const,
+				error: { errorType: 'providerError', message: 'failed' },
+			},
+			isMultiRoot: false,
+			folderCount: 1,
+		};
+
+		reporter.turnCompleted({ provider: 'copilot', ...common });
+		reporter.turnCompleted({ provider: 'claude', ...common });
+
+		assert.deepStrictEqual(service.standardEvents.map(event => ({
+			eventName: event.eventName,
+			provider: event.data?.provider,
+			copilotSku: event.data?.copilotSku,
+		})), [
+			{ eventName: 'agentHost.turnCompleted', provider: 'copilot', copilotSku: 'copilot_for_business_seat' },
+			{ eventName: 'agentHost.turnFailed', provider: 'copilot', copilotSku: 'copilot_for_business_seat' },
+			{ eventName: 'agentHost.turnCompleted', provider: 'claude', copilotSku: undefined },
+			{ eventName: 'agentHost.turnFailed', provider: 'claude', copilotSku: undefined },
+		]);
 	});
 
 	test('toolApproval emits chat.toolApproval with AH discriminators and reason mapping', () => {

--- a/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
+++ b/src/vs/platform/agentHost/test/node/shared/copilotApiService.test.ts
@@ -286,7 +286,7 @@ suite('CopilotApiService', () => {
 			assert.strictEqual(captured().url, 'https://custom.copilot.example.com/v1/messages');
 		});
 
-		test('reuses endpoint discovery when resolving the GitHub login', async () => {
+		test('reuses endpoint discovery when resolving GitHub login and Copilot SKU', async () => {
 			let discoveryCount = 0;
 			const service = createService(async input => {
 				const url = getUrl(input);
@@ -294,6 +294,7 @@ suite('CopilotApiService', () => {
 					discoveryCount++;
 					return new Response(JSON.stringify({
 						login: 'octocat',
+						access_type_sku: 'copilot_for_business_seat',
 						endpoints: { api: 'https://custom.copilot.example.com' },
 					}), { status: 200 });
 				}
@@ -302,10 +303,12 @@ suite('CopilotApiService', () => {
 
 			const apiEndpoint = await service.resolveApiEndpoint('gh-tok');
 			const login = await service.resolveUserLogin('gh-tok');
+			const copilotSku = await service.resolveCopilotSku('gh-tok');
 
-			assert.deepStrictEqual({ apiEndpoint, login, discoveryCount }, {
+			assert.deepStrictEqual({ apiEndpoint, login, copilotSku, discoveryCount }, {
 				apiEndpoint: 'https://custom.copilot.example.com',
 				login: 'octocat',
+				copilotSku: 'copilot_for_business_seat',
 				discoveryCount: 1,
 			});
 		});

--- a/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
+++ b/src/vs/platform/telemetry/common/languageModelToolTelemetry.ts
@@ -24,6 +24,7 @@ export type LanguageModelToolInvokedEvent = LanguageModelToolTelemetryData & {
 	prepareTimeMs?: number;
 	invocationTimeMs?: number;
 	provider?: string;
+	copilotSku?: string;
 	resultSizeInCharacters?: number;
 	turnId?: string;
 	model?: string | TelemetryTrustedValue<string>;
@@ -35,6 +36,7 @@ export type LanguageModelToolInvokedClassification = LanguageModelToolTelemetryC
 	prepareTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in prepareToolInvocation method in milliseconds.' };
 	invocationTimeMs?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; comment: 'Time spent in tool invoke method in milliseconds.' };
 	provider?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The agent host provider that invoked the tool (e.g. copilotcli, claude, codex), if applicable.' };
+	copilotSku?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The raw Copilot entitlement SKU, when the tool invocation uses the Copilot provider and account discovery returned one.' };
 	resultSizeInCharacters?: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Length of the serialized Agent Host tool result in UTF-16 code units, if applicable.' };
 	turnId?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier of the Agent Host turn containing the tool invocation, if applicable.' };
 	model?: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The trusted provider model identifier that produced the tool call, or a generic value for BYOK and unknown models, if applicable.' };


### PR DESCRIPTION
## Summary

- expose the raw Copilot entitlement SKU discovered from `/copilot_internal/user`
- attach it to provider-scoped Agent Host telemetry, including turn, tool, and failure events
- omit the dimension when unavailable and for non-Copilot providers

## Semantics

`copilotSku` carries the raw `access_type_sku` entitlement value. It remains distinct from forwarded SDK `copilot_plan` metadata and applies to Copilot BYOK turns as account context.

## Validation

- `npm run transpile-client`
- 126 targeted Agent Host tests
- `git diff --check origin/main...HEAD`

Full `typecheck-client` is currently blocked by pre-existing implicit-`any` errors in `src/vs/workbench/services/assignment/common/assignmentService.ts` on `main`; this PR does not modify that file.