### PR TITLE
chat: identify managed settings client via query parameters

### DIFF
--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -53,7 +53,7 @@ import { IPolicyService, PolicyValueSource } from '../../../platform/policy/comm
 import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, INativeManagedSettingsService, IFileManagedSettingsService, ManagedSettingsChannel, ManagedSettingsSource, normalizeManagedSettings, projectManagedSettings, pickManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
 import { IManagedSettingPolicyDefinition, ManagedSettingsData } from '../../../base/common/policy.js';
 import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
-import { adaptManagedSettings, IManagedSettingsResponse } from '../../services/accounts/browser/managedSettings.js';
+import { adaptManagedSettings, appendManagedSettingsClientIdentity, IManagedSettingsResponse } from '../../services/accounts/browser/managedSettings.js';
 import { isObject } from '../../../base/common/types.js';
 import * as json from '../../../base/common/json.js';
 import { getParseErrorMessage } from '../../../base/common/jsonErrorMessages.js';
@@ -1062,6 +1062,7 @@ class PolicyDiagnosticsAction extends Action2 {
 
 			const fetchStatus = defaultAccountService.managedSettingsFetchStatus;
 			const fetchedAt = defaultAccountService.managedSettingsFetchedAt;
+			const clientIdentity = appendManagedSettingsClientIdentity('https://api.github.com/copilot_internal/managed_settings', productService);
 			const compatibilityError = defaultAccountService.managedSettingsCompatibilityError;
 			content += '#### GitHub Server API\n\n';
 			content += markdownTable(
@@ -1069,6 +1070,7 @@ class PolicyDiagnosticsAction extends Action2 {
 				[
 					['Endpoint', '/copilot_internal/managed_settings'],
 					['Last fetch', fetchStatus === null ? 'never' : `${fetchStatus}${fetchedAt ? ` at ${new Date(fetchedAt).toLocaleString()}` : ''}`],
+					['Client identity', new URL(clientIdentity).search.replace(/^\?/, '')],
 					['Compatibility', compatibilityError ? `update required (${compatibilityError.clientVersion ?? '?'} → ${compatibilityError.minimumClientVersion ?? '?'})` : 'compatible or not evaluated'],
 					['Contributes winning keys', channelContributes('server') ? 'yes' : 'no']
 				]

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -32,7 +32,7 @@ import { AuthenticationSession, AuthenticationSessionAccount, IAuthenticationExt
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 import { IExtensionService } from '../../extensions/common/extensions.js';
 import { IHostService } from '../../host/browser/host.js';
-import { adaptManagedSettings, IManagedSettingsResponse, parseManagedSettingsCompatibilityError } from './managedSettings.js';
+import { adaptManagedSettings, appendManagedSettingsClientIdentity, IManagedSettingsResponse, parseManagedSettingsCompatibilityError } from './managedSettings.js';
 
 interface IDefaultAccountConfig {
 	readonly preferredExtensions: string[];
@@ -326,6 +326,7 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		@IRequestService private readonly requestService: IRequestService,
 		@ILogService private readonly logService: ILogService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
+		@IProductService private readonly productService: IProductService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IHostService private readonly hostService: IHostService,
@@ -957,9 +958,10 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 			return { kind: 'unavailable' };
 		}
 
-		this.logService.debug('[DefaultAccount] Fetching managed settings from:', managedSettingsUrl);
+		const requestUrl = appendManagedSettingsClientIdentity(managedSettingsUrl, this.productService);
+		this.logService.debug('[DefaultAccount] Fetching managed settings from:', requestUrl);
 		const rateLimitBackoffActive = Date.now() < this._rateLimitBackoffUntil;
-		const response = await this.request(managedSettingsUrl, 'GET', undefined, sessions, CancellationToken.None, 'defaultAccount.managedSettings', MANAGED_SETTINGS_REQUEST_TIMEOUT_MS);
+		const response = await this.request(requestUrl, 'GET', undefined, sessions, CancellationToken.None, 'defaultAccount.managedSettings', MANAGED_SETTINGS_REQUEST_TIMEOUT_MS);
 		if (!response) {
 			this.logService.debug('[DefaultAccount] Managed settings fetch returned no response (network error, all sessions rejected, or active rate-limit backoff); falling back to local-only policy');
 			this.reportManagedSettingsOutcome('no-response', rateLimitBackoffActive);

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -4,9 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IPolicyData } from '../../../../base/common/defaultAccount.js';
+import { IProductConfiguration } from '../../../../base/common/product.js';
 import { isString } from '../../../../base/common/types.js';
 import { IManagedSettingsCompatibilityError, MANAGED_SETTINGS_UPDATE_REQUIRED_ERROR_CODE } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { normalizeManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
+
+/**
+ * Client identity VS Code reports to the managed settings service. It names this codebase's own
+ * managed settings implementation, which is distinct from the `copilot-runtime` implementation
+ * VS Code relays a subset of these settings into.
+ */
+export const MANAGED_SETTINGS_CLIENT_ID = 'vscode';
 
 /**
  * A single MCP server matcher entry in the `allowedMcpServers` / `deniedMcpServers` managed
@@ -69,6 +77,36 @@ export interface IManagedSettingsResponse {
 	};
 	/** Any unknown keys in the response are accepted for forward compatibility. */
 	readonly [key: string]: unknown;
+}
+
+/**
+ * Append the client identity to a `managed_settings` request URL, naming the implementations that
+ * parse and enforce the response so the service can fail closed when they are too old to honor a
+ * setting it would otherwise deliver.
+ *
+ * The identity travels in the query string rather than in headers because neither available
+ * channel survives the trip: `User-Agent` is a forbidden header that `fetch` refuses to set (see
+ * `getRequestHeaders` in `base/parts/request/common/requestImpl.ts`), and custom headers are
+ * dropped before reaching the service unless they are explicitly allow-listed. The query string is
+ * subject to neither restriction and behaves identically on desktop and web.
+ *
+ * Returns the URL unchanged when it cannot be parsed, leaving the request itself intact.
+ */
+export function appendManagedSettingsClientIdentity(url: string, product: Pick<IProductConfiguration, 'version' | 'copilotVersions'>): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return url;
+	}
+
+	parsed.searchParams.set('client_id', MANAGED_SETTINGS_CLIENT_ID);
+	parsed.searchParams.set('client_version', product.version);
+	const runtimeVersion = product.copilotVersions?.runtime;
+	if (runtimeVersion) {
+		parsed.searchParams.set('copilot_runtime_version', runtimeVersion);
+	}
+	return parsed.toString();
 }
 
 interface IManagedSettingsCompatibilityErrorResponse {

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -14,7 +14,7 @@ import { normalizeManagedSettings } from '../../../../platform/policy/common/cop
  * managed settings implementation, which is distinct from the `copilot-runtime` implementation
  * VS Code relays a subset of these settings into.
  */
-export const MANAGED_SETTINGS_CLIENT_ID = 'vscode';
+const MANAGED_SETTINGS_CLIENT_ID = 'vscode';
 
 /**
  * A single MCP server matcher entry in the `allowedMcpServers` / `deniedMcpServers` managed
@@ -82,15 +82,13 @@ export interface IManagedSettingsResponse {
 /**
  * Append the client identity to a `managed_settings` request URL, naming the implementations that
  * parse and enforce the response so the service can fail closed when they are too old to honor a
- * setting it would otherwise deliver.
+ * setting it would otherwise deliver. `copilot_runtime_version` is present only when a runtime is
+ * bundled.
  *
- * The identity travels in the query string rather than in headers because neither available
- * channel survives the trip: `User-Agent` is a forbidden header that `fetch` refuses to set (see
- * `getRequestHeaders` in `base/parts/request/common/requestImpl.ts`), and custom headers are
- * dropped before reaching the service unless they are explicitly allow-listed. The query string is
- * subject to neither restriction and behaves identically on desktop and web.
- *
- * Returns the URL unchanged when it cannot be parsed, leaving the request itself intact.
+ * Existing query parameters are preserved, and the URL is returned unchanged when it cannot be
+ * parsed so a malformed `managedSettingsUrl` cannot turn into a thrown request. The identity
+ * travels in the query string because neither header channel reaches the service; see the PR and
+ * ADR for that rationale.
  */
 export function appendManagedSettingsClientIdentity(url: string, product: Pick<IProductConfiguration, 'version' | 'copilotVersions'>): string {
 	let parsed: URL;
@@ -105,6 +103,9 @@ export function appendManagedSettingsClientIdentity(url: string, product: Pick<I
 	const runtimeVersion = product.copilotVersions?.runtime;
 	if (runtimeVersion) {
 		parsed.searchParams.set('copilot_runtime_version', runtimeVersion);
+	} else {
+		// Never let a value configured on the endpoint URL stand in for a runtime we did not bundle.
+		parsed.searchParams.delete('copilot_runtime_version');
 	}
 	return parsed.toString();
 }

--- a/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
@@ -52,14 +52,12 @@ suite('DefaultAccountProvider managed settings', () => {
 
 		assert.deepStrictEqual({
 			requestCount: requestService.requestCount,
-			headers: requestService.requests[0].headers,
+			requestQuery: new URL(requestService.requests[0].url!).search,
 			first: first.data,
 			second: second.data,
 		}, {
 			requestCount: 1,
-			// The request carries authorization only: client-identity headers are dropped by
-			// GitHub's edge, so we do not send any.
-			headers: { 'Authorization': 'Bearer token' },
+			requestQuery: '?client_id=vscode&client_version=1.132.0&copilot_runtime_version=0.0.344',
 			first: cachedPolicy.policyData,
 			second: cachedPolicy.policyData,
 		});
@@ -178,7 +176,7 @@ suite('DefaultAccountProvider managed settings', () => {
 			if (options.url?.endsWith('/copilot_internal/user')) {
 				return jsonResponse({ chat_enabled: true });
 			}
-			if (options.url?.endsWith('/copilot_internal/managed_settings')) {
+			if (options.url?.includes('/copilot_internal/managed_settings')) {
 				return jsonResponse({});
 			}
 			throw new Error(`Unexpected request: ${options.url}`);

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -25,11 +25,13 @@ suite('adaptManagedSettings', () => {
 			}),
 			withoutRuntime: appendManagedSettingsClientIdentity('https://api.github.com/copilot_internal/managed_settings', { version: '1.132.0' }),
 			preservesExistingQuery: appendManagedSettingsClientIdentity('https://api.github.com/copilot_internal/managed_settings?foo=bar', { version: '1.132.0' }),
+			dropsStaleRuntimeVersion: appendManagedSettingsClientIdentity('https://api.github.com/copilot_internal/managed_settings?copilot_runtime_version=0.0.1', { version: '1.132.0' }),
 			unparseableUrl: appendManagedSettingsClientIdentity('not a url', { version: '1.132.0' }),
 		}, {
 			withRuntime: 'https://api.github.com/copilot_internal/managed_settings?client_id=vscode&client_version=1.132.0&copilot_runtime_version=0.0.344',
 			withoutRuntime: 'https://api.github.com/copilot_internal/managed_settings?client_id=vscode&client_version=1.132.0',
 			preservesExistingQuery: 'https://api.github.com/copilot_internal/managed_settings?foo=bar&client_id=vscode&client_version=1.132.0',
+			dropsStaleRuntimeVersion: 'https://api.github.com/copilot_internal/managed_settings?client_id=vscode&client_version=1.132.0',
 			unparseableUrl: 'not a url',
 		});
 	});

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { adaptManagedSettings, IManagedSettingsResponse, parseManagedSettingsCompatibilityError } from '../../browser/managedSettings.js';
+import { adaptManagedSettings, appendManagedSettingsClientIdentity, IManagedSettingsResponse, parseManagedSettingsCompatibilityError } from '../../browser/managedSettings.js';
 
 suite('adaptManagedSettings', () => {
 
@@ -14,6 +14,23 @@ suite('adaptManagedSettings', () => {
 	test('empty response yields an empty managed settings bag', () => {
 		assert.deepStrictEqual(adaptManagedSettings({}), {
 			managedSettings: {},
+		});
+	});
+
+	test('appends client identity to the request url', () => {
+		assert.deepStrictEqual({
+			withRuntime: appendManagedSettingsClientIdentity('https://api.github.com/copilot_internal/managed_settings', {
+				version: '1.132.0',
+				copilotVersions: { runtime: '0.0.344', sdk: '0.1.0' },
+			}),
+			withoutRuntime: appendManagedSettingsClientIdentity('https://api.github.com/copilot_internal/managed_settings', { version: '1.132.0' }),
+			preservesExistingQuery: appendManagedSettingsClientIdentity('https://api.github.com/copilot_internal/managed_settings?foo=bar', { version: '1.132.0' }),
+			unparseableUrl: appendManagedSettingsClientIdentity('not a url', { version: '1.132.0' }),
+		}, {
+			withRuntime: 'https://api.github.com/copilot_internal/managed_settings?client_id=vscode&client_version=1.132.0&copilot_runtime_version=0.0.344',
+			withoutRuntime: 'https://api.github.com/copilot_internal/managed_settings?client_id=vscode&client_version=1.132.0',
+			preservesExistingQuery: 'https://api.github.com/copilot_internal/managed_settings?foo=bar&client_id=vscode&client_version=1.132.0',
+			unparseableUrl: 'not a url',
 		});
 	});
 


### PR DESCRIPTION
Per ADR 004, the managed settings service needs to know which implementation will parse and enforce the response so it can fail closed when that implementation is too old to honor a setting it would otherwise deliver. VS Code signalled this with `Editor-Version` and `Copilot-Runtime-Version` headers, and we found that neither one ever reached the service. #330762 removed those dead headers; this PR is the replacement mechanism, now rebased on main.

## Why not headers

Two separate mechanisms are in the way, and each rules out one option:

- `User-Agent` is a forbidden request header. `fetch` refuses to set it, and `getRequestHeaders` in `base/parts/request/common/requestImpl.ts` already strips it before the request goes out. This applies on desktop too: the workbench's `NativeRequestService` calls the same fetch-based implementation and only uses IPC for proxy and certificate lookups. No `Access-Control-Allow-Headers` entry can grant a forbidden header back.
- Custom headers are dropped before reaching the monolith unless they are explicitly allow-listed. The current allow-list is `Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, Accept-Encoding, X-GitHub-OTP, X-Requested-With, User-Agent, GraphQL-Features, X-Github-Next-Global-ID, X-GitHub-Api-Version, X-Fetch-Nonce, Copilot-Integration-Id`. Neither of the two headers was on it. The request still succeeded, so this failed silently.

## Approach

The identity moves into the query string, which is subject to neither restriction and behaves identically on desktop and web:

```
/copilot_internal/managed_settings?client_id=vscode&client_version=1.134.0&copilot_runtime_version=0.0.344
```

`appendManagedSettingsClientIdentity` builds this with the `URL` API, so existing query parameters are preserved, and it returns the URL unchanged if it cannot be parsed so a malformed `managedSettingsUrl` in product.json can never turn into a thrown request.

`copilot_runtime_version` is sent separately and only when a runtime is bundled. VS Code relays a subset of these settings into the runtime it spawns, so enforcement here is really a pair of implementations rather than the single `client_id` and `client_version` the ADR's `ComputeClientSettingsRequest` models. Flagging that as an ADR gap rather than papering over it.

The `IProductService` injection that #330762 dropped comes back here, since this is what needs it.

## Worth a careful look

This needs a corresponding change in the settings service to read the query parameters. Until that lands the parameters are inert, which is the same state we are in today, so there is no regression in the meantime.

Policy Diagnostics now reports the client identity actually attached to the request instead of a computed header value that was never sent.

## Testing

`./scripts/test.sh --grep "adaptManagedSettings|DefaultAccountProvider managed settings"` - 31 passing, plus a clean `npm run typecheck-client`.
