### PR TITLE
chat: remove managed settings headers that never reach the service

### DIFF
--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -53,7 +53,7 @@ import { IPolicyService, PolicyValueSource } from '../../../platform/policy/comm
 import { COPILOT_ENABLED_PLUGINS_KEY, COPILOT_EXTRA_MARKETPLACES_KEY, COPILOT_STRICT_MARKETPLACES_KEY, INativeManagedSettingsService, IFileManagedSettingsService, ManagedSettingsChannel, ManagedSettingsSource, normalizeManagedSettings, projectManagedSettings, pickManagedSettings } from '../../../platform/policy/common/copilotManagedSettings.js';
 import { IManagedSettingPolicyDefinition, ManagedSettingsData } from '../../../base/common/policy.js';
 import { APPROVED_ACCOUNT_ORGANIZATIONS_POLICY_NAME, IAccountPolicyGateService } from '../../services/policies/common/accountPolicyService.js';
-import { adaptManagedSettings, getManagedSettingsClientHeaders, IManagedSettingsResponse } from '../../services/accounts/browser/managedSettings.js';
+import { adaptManagedSettings, IManagedSettingsResponse } from '../../services/accounts/browser/managedSettings.js';
 import { isObject } from '../../../base/common/types.js';
 import * as json from '../../../base/common/json.js';
 import { getParseErrorMessage } from '../../../base/common/jsonErrorMessages.js';
@@ -1062,7 +1062,6 @@ class PolicyDiagnosticsAction extends Action2 {
 
 			const fetchStatus = defaultAccountService.managedSettingsFetchStatus;
 			const fetchedAt = defaultAccountService.managedSettingsFetchedAt;
-			const clientHeaders = getManagedSettingsClientHeaders(productService);
 			const compatibilityError = defaultAccountService.managedSettingsCompatibilityError;
 			content += '#### GitHub Server API\n\n';
 			content += markdownTable(
@@ -1070,8 +1069,6 @@ class PolicyDiagnosticsAction extends Action2 {
 				[
 					['Endpoint', '/copilot_internal/managed_settings'],
 					['Last fetch', fetchStatus === null ? 'never' : `${fetchStatus}${fetchedAt ? ` at ${new Date(fetchedAt).toLocaleString()}` : ''}`],
-					['Editor-Version', String(clientHeaders['Editor-Version'])],
-					['Copilot-Runtime-Version', String(clientHeaders['Copilot-Runtime-Version'] ?? 'not available')],
 					['Compatibility', compatibilityError ? `update required (${compatibilityError.clientVersion ?? '?'} → ${compatibilityError.minimumClientVersion ?? '?'})` : 'compatible or not evaluated'],
 					['Contributes winning keys', channelContributes('server') ? 'yes' : 'no']
 				]

--- a/src/vs/workbench/services/accounts/browser/defaultAccount.ts
+++ b/src/vs/workbench/services/accounts/browser/defaultAccount.ts
@@ -14,7 +14,7 @@ import { equals } from '../../../../base/common/objects.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { IDefaultChatAgent } from '../../../../base/common/product.js';
 import { isString, isUndefined, Mutable } from '../../../../base/common/types.js';
-import { IHeaders, IRequestContext } from '../../../../base/parts/request/common/request.js';
+import { IRequestContext } from '../../../../base/parts/request/common/request.js';
 import { localize2 } from '../../../../nls.js';
 import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
@@ -32,7 +32,7 @@ import { AuthenticationSession, AuthenticationSessionAccount, IAuthenticationExt
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 import { IExtensionService } from '../../extensions/common/extensions.js';
 import { IHostService } from '../../host/browser/host.js';
-import { adaptManagedSettings, getManagedSettingsClientHeaders, IManagedSettingsResponse, parseManagedSettingsCompatibilityError } from './managedSettings.js';
+import { adaptManagedSettings, IManagedSettingsResponse, parseManagedSettingsCompatibilityError } from './managedSettings.js';
 
 interface IDefaultAccountConfig {
 	readonly preferredExtensions: string[];
@@ -326,7 +326,6 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 		@IRequestService private readonly requestService: IRequestService,
 		@ILogService private readonly logService: ILogService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
-		@IProductService private readonly productService: IProductService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IStorageService private readonly storageService: IStorageService,
 		@IHostService private readonly hostService: IHostService,
@@ -960,7 +959,7 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 
 		this.logService.debug('[DefaultAccount] Fetching managed settings from:', managedSettingsUrl);
 		const rateLimitBackoffActive = Date.now() < this._rateLimitBackoffUntil;
-		const response = await this.request(managedSettingsUrl, 'GET', undefined, sessions, CancellationToken.None, 'defaultAccount.managedSettings', MANAGED_SETTINGS_REQUEST_TIMEOUT_MS, getManagedSettingsClientHeaders(this.productService));
+		const response = await this.request(managedSettingsUrl, 'GET', undefined, sessions, CancellationToken.None, 'defaultAccount.managedSettings', MANAGED_SETTINGS_REQUEST_TIMEOUT_MS);
 		if (!response) {
 			this.logService.debug('[DefaultAccount] Managed settings fetch returned no response (network error, all sessions rejected, or active rate-limit backoff); falling back to local-only policy');
 			this.reportManagedSettingsOutcome('no-response', rateLimitBackoffActive);
@@ -1057,9 +1056,9 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 
 	private _rateLimitBackoffUntil = 0;
 
-	private async request(url: string, type: 'GET', body: undefined, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number, headers?: IHeaders): Promise<IRequestContext | undefined>;
-	private async request(url: string, type: 'POST', body: object, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number, headers?: IHeaders): Promise<IRequestContext | undefined>;
-	private async request(url: string, type: 'GET' | 'POST', body: object | undefined, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number, headers?: IHeaders): Promise<IRequestContext | undefined> {
+	private async request(url: string, type: 'GET', body: undefined, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number): Promise<IRequestContext | undefined>;
+	private async request(url: string, type: 'POST', body: object, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number): Promise<IRequestContext | undefined>;
+	private async request(url: string, type: 'GET' | 'POST', body: object | undefined, sessions: AuthenticationSession[], token: CancellationToken, callSite: string, requestTimeoutMs?: number): Promise<IRequestContext | undefined> {
 		// Rate-limit backoff: when any prior `/copilot_internal/*` request was
 		// throttled (429 or 403 + `X-RateLimit-Remaining: 0`), every subsequent
 		// request is short-circuited until the parsed `Retry-After` elapses.
@@ -1088,7 +1087,6 @@ export class DefaultAccountProvider extends Disposable implements IDefaultAccoun
 					disableCache: true,
 					timeout: requestTimeoutMs,
 					headers: {
-						...headers,
 						'Authorization': `Bearer ${session.accessToken}`
 					},
 					callSite

--- a/src/vs/workbench/services/accounts/browser/managedSettings.ts
+++ b/src/vs/workbench/services/accounts/browser/managedSettings.ts
@@ -4,9 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IPolicyData } from '../../../../base/common/defaultAccount.js';
-import { IProductConfiguration } from '../../../../base/common/product.js';
 import { isString } from '../../../../base/common/types.js';
-import { IHeaders } from '../../../../base/parts/request/common/request.js';
 import { IManagedSettingsCompatibilityError, MANAGED_SETTINGS_UPDATE_REQUIRED_ERROR_CODE } from '../../../../platform/defaultAccount/common/defaultAccount.js';
 import { normalizeManagedSettings } from '../../../../platform/policy/common/copilotManagedSettings.js';
 
@@ -71,17 +69,6 @@ export interface IManagedSettingsResponse {
 	};
 	/** Any unknown keys in the response are accepted for forward compatibility. */
 	readonly [key: string]: unknown;
-}
-
-export function getManagedSettingsClientHeaders(product: Pick<IProductConfiguration, 'version' | 'copilotVersions'>): IHeaders {
-	const headers: IHeaders = {
-		'Editor-Version': `vscode/${product.version}`,
-	};
-	const runtimeVersion = product.copilotVersions?.runtime;
-	if (runtimeVersion) {
-		headers['Copilot-Runtime-Version'] = `copilot-runtime/${runtimeVersion}`;
-	}
-	return headers;
 }
 
 interface IManagedSettingsCompatibilityErrorResponse {

--- a/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
@@ -52,14 +52,10 @@ suite('DefaultAccountProvider managed settings', () => {
 
 		assert.deepStrictEqual({
 			requestCount: requestService.requestCount,
-			editorVersion: requestService.requests[0].headers?.['Editor-Version'],
-			runtimeVersion: requestService.requests[0].headers?.['Copilot-Runtime-Version'],
 			first: first.data,
 			second: second.data,
 		}, {
 			requestCount: 1,
-			editorVersion: 'vscode/1.132.0',
-			runtimeVersion: 'copilot-runtime/0.0.344',
 			first: cachedPolicy.policyData,
 			second: cachedPolicy.policyData,
 		});

--- a/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/defaultAccount.test.ts
@@ -52,10 +52,14 @@ suite('DefaultAccountProvider managed settings', () => {
 
 		assert.deepStrictEqual({
 			requestCount: requestService.requestCount,
+			headers: requestService.requests[0].headers,
 			first: first.data,
 			second: second.data,
 		}, {
 			requestCount: 1,
+			// The request carries authorization only: client-identity headers are dropped by
+			// GitHub's edge, so we do not send any.
+			headers: { 'Authorization': 'Bearer token' },
 			first: cachedPolicy.policyData,
 			second: cachedPolicy.policyData,
 		});

--- a/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
+++ b/src/vs/workbench/services/accounts/test/browser/managedSettings.test.ts
@@ -5,7 +5,7 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { adaptManagedSettings, getManagedSettingsClientHeaders, IManagedSettingsResponse, parseManagedSettingsCompatibilityError } from '../../browser/managedSettings.js';
+import { adaptManagedSettings, IManagedSettingsResponse, parseManagedSettingsCompatibilityError } from '../../browser/managedSettings.js';
 
 suite('adaptManagedSettings', () => {
 
@@ -14,24 +14,6 @@ suite('adaptManagedSettings', () => {
 	test('empty response yields an empty managed settings bag', () => {
 		assert.deepStrictEqual(adaptManagedSettings({}), {
 			managedSettings: {},
-		});
-	});
-
-	test('builds available client identity headers', () => {
-		assert.deepStrictEqual({
-			withRuntime: getManagedSettingsClientHeaders({
-				version: '1.132.0',
-				copilotVersions: { runtime: '0.0.344', sdk: '0.1.0' },
-			}),
-			withoutRuntime: getManagedSettingsClientHeaders({ version: '1.132.0' }),
-		}, {
-			withRuntime: {
-				'Editor-Version': 'vscode/1.132.0',
-				'Copilot-Runtime-Version': 'copilot-runtime/0.0.344',
-			},
-			withoutRuntime: {
-				'Editor-Version': 'vscode/1.132.0',
-			},
 		});
 	});
 


### PR DESCRIPTION
## Why

We send two custom headers on `GET /copilot_internal/managed_settings` to identify which implementation parses and enforces the response, per Copilot ADR 004:

- `Editor-Version: vscode/<version>`
- `Copilot-Runtime-Version: copilot-runtime/<version>`

They never reach the service. GitHub's edge forwards only an allow-listed set of request headers:

> `Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, Accept-Encoding, X-GitHub-OTP, X-Requested-With, User-Agent, GraphQL-Features, X-Github-Next-Global-ID, X-GitHub-Api-Version, X-Fetch-Nonce, Copilot-Integration-Id`

Neither header is on that list, so both are silently dropped. The request itself still succeeds; only the headers vanish.

That makes this dead code that implies we send a compatibility signal we do not actually send. ADR 004 has the service fail closed for clients that cannot enforce a delivered setting, and the Policy Diagnostics view currently displays these headers as if they were sent. Removing them makes the gap honest and visible.

## What

Removal only. No replacement mechanism here; the real identity channel (a query-string parameter is the leading candidate) is being iterated on separately in #330759.

- Delete `getManagedSettingsClientHeaders` from `managedSettings.ts`.
- Drop the trailing `headers?: IHeaders` parameter from the private `request()` helper in `defaultAccount.ts` (managed settings was its only caller) and the `...headers` spread; the `Authorization` header is unchanged.
- Remove the two header rows from the "GitHub Server API" table in the Policy Diagnostics developer action, so it no longer advertises headers we do not send.
- Update the two affected tests.

466 / compatibility-error handling, retries, caching, and rate limiting are untouched. We still parse a compatibility rejection if the service sends one.

## Validation

- `npm run typecheck-client` clean
- `npm run transpile-client` clean
- `./scripts/test.sh --grep "adaptManagedSettings|DefaultAccountProvider managed settings"` - 30 passing
- No remaining references to `Editor-Version`, `Copilot-Runtime-Version`, or `getManagedSettingsClientHeaders` in `src/`