### PR TITLE
chat: support custom endpoint thinking modes

### DIFF
--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -2091,6 +2091,21 @@
                     "title": "API Type",
                     "markdownDescription": "Request/response format used to talk to this endpoint:\n- `chat-completions`: Chat Completions API (default).\n- `responses`: Responses API.\n- `messages`: Messages API.\n\nWhen omitted, falls back to the group-level `apiType`, then to the URL path."
                   },
+                  "adaptiveThinking": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Whether the Messages API model supports adaptive thinking. When enabled, requests use `thinking.type: \"adaptive\"`."
+                  },
+                  "minThinkingBudget": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "markdownDescription": "Minimum thinking-token budget supported by a non-adaptive Messages API model. `maxThinkingBudget` must also be set."
+                  },
+                  "maxThinkingBudget": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "markdownDescription": "Maximum thinking-token budget supported by a non-adaptive Messages API model. `minThinkingBudget` must also be set."
+                  },
                   "toolCalling": {
                     "type": "boolean",
                     "description": "Whether the model supports tool calling"

--- a/extensions/copilot/src/extension/byok/common/byokProvider.ts
+++ b/extensions/copilot/src/extension/byok/common/byokProvider.ts
@@ -64,6 +64,8 @@ export interface BYOKModelCapabilities {
 	vision: boolean;
 	thinking?: boolean;
 	adaptiveThinking?: boolean;
+	minThinkingBudget?: number;
+	maxThinkingBudget?: number;
 	streaming?: boolean;
 	editTools?: EndpointEditToolName[];
 	requestHeaders?: Record<string, string>;
@@ -157,6 +159,8 @@ export function resolveModelInfo(modelId: string, providerName: string, knownMod
 				vision: !!knownModelInfo?.vision,
 				thinking: !!knownModelInfo?.thinking,
 				adaptive_thinking: !!knownModelInfo?.adaptiveThinking,
+				min_thinking_budget: knownModelInfo?.minThinkingBudget,
+				max_thinking_budget: knownModelInfo?.maxThinkingBudget,
 				reasoning_effort: knownModelInfo?.supportsReasoningEffort
 			},
 			tokenizer: TokenizerType.O200K,

--- a/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/customEndpointProvider.ts
@@ -98,6 +98,9 @@ interface _CustomEndpointModelConfig {
 	toolCalling: boolean;
 	vision: boolean;
 	thinking?: boolean;
+	adaptiveThinking?: boolean;
+	minThinkingBudget?: number;
+	maxThinkingBudget?: number;
 	streaming?: boolean;
 	editTools?: EndpointEditToolName[];
 	requestHeaders?: Record<string, string>;
@@ -162,6 +165,9 @@ export class CustomEndpointBYOKModelProvider extends AbstractOpenAICompatibleLMP
 			name: model.name,
 			url,
 			thinking: modelConfiguration?.thinking ?? false,
+			adaptiveThinking: modelConfiguration?.adaptiveThinking,
+			minThinkingBudget: modelConfiguration?.minThinkingBudget,
+			maxThinkingBudget: modelConfiguration?.maxThinkingBudget,
 			streaming: modelConfiguration?.streaming,
 			requestHeaders: modelConfiguration?.requestHeaders,
 			modelOptions: modelConfiguration?.modelOptions,

--- a/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
+++ b/extensions/copilot/src/extension/byok/vscode-node/test/customEndpointProvider.spec.ts
@@ -4,26 +4,70 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { OpenAI, Raw } from '@vscode/prompt-tsx';
+import * as vscode from 'vscode';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { BlockedExtensionService, IBlockedExtensionService } from '../../../../platform/chat/common/blockedExtensionService';
-import { ChatLocation } from '../../../../platform/chat/common/commonTypes';
+import { IChatMLFetcher, type IFetchMLOptions } from '../../../../platform/chat/common/chatMLFetcher';
+import { ChatLocation, type ChatResponse, type ChatResponses } from '../../../../platform/chat/common/commonTypes';
+import { MockChatMLFetcher } from '../../../../platform/chat/test/common/mockChatMLFetcher';
 import { IChatModelInformation, ModelSupportedEndpoint } from '../../../../platform/endpoint/common/endpointProvider';
+import type { IChatEndpoint } from '../../../../platform/networking/common/networking';
 import { ITestingServicesAccessor } from '../../../../platform/test/node/services';
 import { TokenizerType } from '../../../../util/common/tokenizer';
+import { Event } from '../../../../util/vs/base/common/event';
 import { DisposableStore } from '../../../../util/vs/base/common/lifecycle';
 import { SyncDescriptor } from '../../../../util/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService } from '../../../../util/vs/platform/instantiation/common/instantiation';
 import { createExtensionUnitTestingServices } from '../../../test/node/services';
-import { CustomEndpointOAIEndpoint, hasExplicitApiPath, resolveCustomEndpointUrl } from '../customEndpointProvider';
+import type { OpenAICompatibleLanguageModelChatInformation } from '../abstractLanguageModelChatProvider';
+import type { IBYOKStorageService } from '../byokStorageService';
+import { CustomEndpointBYOKModelProvider, type CustomEndpointModelProviderConfig, CustomEndpointOAIEndpoint, hasExplicitApiPath, resolveCustomEndpointUrl } from '../customEndpointProvider';
+
+class TestCustomEndpointBYOKModelProvider extends CustomEndpointBYOKModelProvider {
+	public createEndpoint(model: OpenAICompatibleLanguageModelChatInformation<CustomEndpointModelProviderConfig>): Promise<IChatEndpoint> {
+		return this.createOpenAIEndPoint(model);
+	}
+}
+
+class CapturingChatMLFetcher implements IChatMLFetcher {
+	declare readonly _serviceBrand: undefined;
+	readonly onDidMakeChatMLRequest = Event.None;
+	readonly requests: IFetchMLOptions[] = [];
+
+	private readonly delegate = new MockChatMLFetcher();
+
+	fetchOne(options: IFetchMLOptions): Promise<ChatResponse> {
+		this.requests.push(options);
+		return this.delegate.fetchOne();
+	}
+
+	fetchMany(): Promise<ChatResponses> {
+		return this.delegate.fetchMany();
+	}
+}
+
+function createStorageService(): IBYOKStorageService {
+	return {
+		getAPIKey: async () => undefined,
+		storeAPIKey: async () => undefined,
+		deleteAPIKey: async () => undefined,
+		getStoredModelConfigs: async () => ({}),
+		saveModelConfig: async () => undefined,
+		removeModelConfig: async () => undefined,
+	};
+}
 
 describe('CustomEndpointBYOKModelProvider', () => {
 	const disposables = new DisposableStore();
 	let accessor: ITestingServicesAccessor;
 	let instaService: IInstantiationService;
+	let chatMLFetcher: CapturingChatMLFetcher;
 
 	beforeEach(() => {
 		const testingServiceCollection = createExtensionUnitTestingServices();
 		testingServiceCollection.define(IBlockedExtensionService, new SyncDescriptor(BlockedExtensionService));
+		chatMLFetcher = new CapturingChatMLFetcher();
+		testingServiceCollection.set(IChatMLFetcher, chatMLFetcher);
 		accessor = disposables.add(testingServiceCollection.createTestingAccessor());
 		instaService = accessor.get(IInstantiationService);
 	});
@@ -143,6 +187,181 @@ describe('CustomEndpointBYOKModelProvider', () => {
 				anthropicVersion: '2023-06-01',
 				authorization: undefined,
 			});
+		});
+
+		it('issue #330712: forwards configured Messages API thinking mode to the request body', async () => {
+			const provider = instaService.createInstance(TestCustomEndpointBYOKModelProvider, createStorageService());
+			const tokenSource = disposables.add(new vscode.CancellationTokenSource());
+			const baseModel = {
+				name: 'Custom Claude',
+				url: 'https://api.example.com',
+				apiType: 'messages' as const,
+				maxInputTokens: 128000,
+				maxOutputTokens: 64000,
+				toolCalling: true,
+				vision: false,
+				thinking: true,
+			};
+			const variants = [
+				{
+					id: 'adaptive',
+					adaptiveThinking: true,
+				},
+				{
+					id: 'budget',
+					minThinkingBudget: 1024,
+					maxThinkingBudget: 32000,
+				},
+				{
+					id: 'unspecified-mode',
+				},
+			].map(model => ({ ...baseModel, ...model }));
+
+			const results = await Promise.all(variants.map(async configuredModel => {
+				const [model] = await provider.provideLanguageModelChatInformation({
+					silent: true,
+					configuration: {
+						apiKey: 'test-api-key',
+						models: [configuredModel],
+					}
+				}, tokenSource.token);
+				const endpoint = await provider.createEndpoint(model);
+				const body = endpoint.createRequestBody({
+					debugName: 'test',
+					messages: [],
+					requestId: `test-${configuredModel.id}`,
+					postOptions: { max_tokens: 64000 },
+					modelCapabilities: { enableThinking: true },
+					finishedCb: undefined,
+					location: ChatLocation.Other,
+				});
+				return {
+					id: configuredModel.id,
+					apiType: endpoint.apiType,
+					supportsAdaptiveThinking: endpoint.supportsAdaptiveThinking,
+					minThinkingBudget: endpoint.minThinkingBudget,
+					maxThinkingBudget: endpoint.maxThinkingBudget,
+					thinking: body.thinking,
+				};
+			}));
+
+			expect(results).toEqual([
+				{
+					id: 'adaptive',
+					apiType: 'messages',
+					supportsAdaptiveThinking: true,
+					minThinkingBudget: undefined,
+					maxThinkingBudget: undefined,
+					thinking: { type: 'adaptive', display: 'summarized' },
+				},
+				{
+					id: 'budget',
+					apiType: 'messages',
+					supportsAdaptiveThinking: false,
+					minThinkingBudget: 1024,
+					maxThinkingBudget: 32000,
+					thinking: { type: 'enabled', budget_tokens: 16000 },
+				},
+				{
+					id: 'unspecified-mode',
+					apiType: 'messages',
+					supportsAdaptiveThinking: false,
+					minThinkingBudget: undefined,
+					maxThinkingBudget: undefined,
+					thinking: undefined,
+				},
+			]);
+		});
+
+		it('issue #330712: exposes thinking mode metadata for every custom endpoint API type', async () => {
+			const provider = instaService.createInstance(TestCustomEndpointBYOKModelProvider, createStorageService());
+			const tokenSource = disposables.add(new vscode.CancellationTokenSource());
+			const results = [];
+
+			for (const apiType of ['chat-completions', 'responses'] as const) {
+				const [model] = await provider.provideLanguageModelChatInformation({
+					silent: true,
+					configuration: {
+						apiKey: 'test-api-key',
+						models: [{
+							id: apiType,
+							name: 'Custom Model',
+							url: 'https://api.example.com',
+							apiType,
+							maxInputTokens: 128000,
+							maxOutputTokens: 64000,
+							toolCalling: true,
+							vision: false,
+							adaptiveThinking: true,
+							minThinkingBudget: 1024,
+							maxThinkingBudget: 32000,
+						}],
+					}
+				}, tokenSource.token);
+
+				const endpoint = await provider.createEndpoint(model);
+				results.push({
+					apiType: endpoint.apiType,
+					supportsAdaptiveThinking: endpoint.supportsAdaptiveThinking,
+					minThinkingBudget: endpoint.minThinkingBudget,
+					maxThinkingBudget: endpoint.maxThinkingBudget,
+				});
+			}
+
+			expect(results).toEqual([
+				{
+					apiType: 'chatCompletions',
+					supportsAdaptiveThinking: true,
+					minThinkingBudget: 1024,
+					maxThinkingBudget: 32000,
+				},
+				{
+					apiType: 'responses',
+					supportsAdaptiveThinking: true,
+					minThinkingBudget: 1024,
+					maxThinkingBudget: 32000,
+				},
+			]);
+		});
+
+		it('issue #330712: reconstructs the request thinking capability after language model IPC', async () => {
+			const provider = instaService.createInstance(TestCustomEndpointBYOKModelProvider, createStorageService());
+			const tokenSource = disposables.add(new vscode.CancellationTokenSource());
+			const [model] = await provider.provideLanguageModelChatInformation({
+				silent: true,
+				configuration: {
+					apiKey: 'test-api-key',
+					models: [{
+						id: 'adaptive',
+						name: 'Custom Claude',
+						url: 'https://api.example.com',
+						apiType: 'messages',
+						maxInputTokens: 128000,
+						maxOutputTokens: 64000,
+						toolCalling: true,
+						vision: false,
+						thinking: true,
+						adaptiveThinking: true,
+					}],
+				}
+			}, tokenSource.token);
+
+			for (const enableThinking of [true, false]) {
+				await provider.provideLanguageModelChatResponse(
+					model,
+					[new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.User, 'hello')],
+					{
+						requestInitiator: 'core',
+						tools: [],
+						toolMode: vscode.LanguageModelChatToolMode.Auto,
+						modelOptions: { _enableThinking: enableThinking },
+					},
+					{ report: () => undefined },
+					tokenSource.token,
+				);
+			}
+
+			expect(chatMLFetcher.requests.map(request => request.modelCapabilities?.enableThinking)).toEqual([true, false]);
 		});
 
 		it('sends Authorization: Bearer for Chat Completions endpoints', () => {

--- a/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
+++ b/extensions/copilot/src/extension/conversation/vscode-node/languageModelAccess.ts
@@ -20,6 +20,7 @@ import { encodeStatefulMarker } from '../../../platform/endpoint/common/stateful
 import { AutoChatEndpoint } from '../../../platform/endpoint/node/autoChatEndpoint';
 import { IAutomodeService, type IAutoModeRoutingRequest } from '../../../platform/endpoint/node/automodeService';
 import { CopilotChatEndpoint } from '../../../platform/endpoint/node/copilotChatEndpoint';
+import type { ExtensionLanguageModelRequestOptions } from '../../../platform/endpoint/vscode-node/extChatEndpoint';
 import { IEnvService, isScenarioAutomation } from '../../../platform/env/common/envService';
 import { IVSCodeExtensionContext } from '../../../platform/extContext/common/extensionContext';
 import { IOctoKitService } from '../../../platform/github/common/githubService';
@@ -27,7 +28,7 @@ import { ILogService } from '../../../platform/log/common/logService';
 import { FinishedCallback, OpenAiFunctionTool, OptionalChatRequestParams } from '../../../platform/networking/common/fetch';
 import { IChatEndpoint, IEndpoint } from '../../../platform/networking/common/networking';
 import { APIUsage } from '../../../platform/networking/common/openai';
-import { IOTelService, type OTelModelOptions } from '../../../platform/otel/common/otelService';
+import { IOTelService } from '../../../platform/otel/common/otelService';
 import { retrieveCapturingTokenByCorrelation, runWithCapturingToken } from '../../../platform/requestLogger/node/requestLogger';
 import { IExperimentationService } from '../../../platform/telemetry/common/nullExperimentationService';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry';
@@ -784,6 +785,7 @@ export class CopilotLanguageModelWrapper extends Disposable {
 		});
 
 
+		const internalModelOptions = (_options as { modelOptions?: ExtensionLanguageModelRequestOptions }).modelOptions;
 		const options: OptionalChatRequestParams = LanguageModelOptions.Default.convert(_options.modelOptions ?? {});
 		const telemetryProperties = { messageSource: `api.${extensionId}` };
 
@@ -808,12 +810,12 @@ export class CopilotLanguageModelWrapper extends Disposable {
 		// Restore CapturingToken context if correlation ID was passed through modelOptions.
 		// This handles BYOK providers where the original AsyncLocalStorage context was lost
 		// when crossing the VS Code IPC boundary.
-		const correlationId = (_options as { modelOptions?: OTelModelOptions }).modelOptions?._capturingTokenCorrelationId;
+		const correlationId = internalModelOptions?._capturingTokenCorrelationId;
 		const capturingToken = correlationId ? retrieveCapturingTokenByCorrelation(correlationId) : undefined;
 
 		// Restore OTel trace context if passed through modelOptions.
 		// This links the wrapper's chat span back to the original invoke_agent trace.
-		const parentTraceContext = (_options as { modelOptions?: OTelModelOptions }).modelOptions?._otelTraceContext ?? undefined;
+		const parentTraceContext = internalModelOptions?._otelTraceContext ?? undefined;
 
 		const makeRequest = () => endpoint.makeChatRequest2({
 			debugName: 'copilotLanguageModelWrapper',
@@ -825,6 +827,7 @@ export class CopilotLanguageModelWrapper extends Disposable {
 			userInitiatedRequest: !!extensionId,
 			telemetryProperties,
 			modelCapabilities: {
+				enableThinking: internalModelOptions?._enableThinking,
 				reasoningEffort: typeof _options.modelConfiguration?.reasoningEffort === 'string' ? _options.modelConfiguration.reasoningEffort : undefined,
 			},
 		}, token);

--- a/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/extChatEndpoint.ts
@@ -19,7 +19,7 @@ import { FinishedCallback, OpenAiFunctionTool, OptionalChatRequestParams } from 
 import { Response } from '../../networking/common/fetcherService';
 import { IChatEndpoint, ICreateEndpointBodyOptions, IEndpointBody, IMakeChatRequestOptions } from '../../networking/common/networking';
 import { APIUsage, ChatCompletion, isApiUsage } from '../../networking/common/openai';
-import { IOTelService } from '../../otel/common/otelService';
+import { IOTelService, type OTelModelOptions } from '../../otel/common/otelService';
 import { retrieveCapturingTokenByCorrelation, storeCapturingTokenForCorrelation } from '../../requestLogger/node/requestLogger';
 import { ITelemetryService } from '../../telemetry/common/telemetry';
 import { TelemetryData } from '../../telemetry/common/telemetryData';
@@ -28,6 +28,13 @@ import { CustomDataPartMimeTypes, modelVendorHandlesCacheBreakpoints } from '../
 import { decodeStatefulMarker, encodeStatefulMarker, rawPartAsStatefulMarker } from '../common/statefulMarkerContainer';
 import { rawPartAsThinkingData } from '../common/thinkingDataContainer';
 import { ExtensionContributedChatTokenizer } from './extChatTokenizer';
+
+/**
+ * Internal model options transported across VS Code's extension-contributed language model boundary.
+ */
+export interface ExtensionLanguageModelRequestOptions extends OTelModelOptions {
+	readonly _enableThinking?: boolean;
+}
 
 enum ChatImageMimeType {
 	PNG = 'image/png',
@@ -170,6 +177,7 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 		location,
 		source,
 		telemetryProperties,
+		modelCapabilities,
 	}: IMakeChatRequestOptions, token: CancellationToken): Promise<ChatResponse> {
 		const vscodeMessages = convertToApiChatMessage(messages, {
 			ignoreStatefulMarker,
@@ -197,7 +205,8 @@ export class ExtensionContributedChatEndpoint implements IChatEndpoint {
 				_capturingTokenCorrelationId: ourRequestId,
 				_otelTraceContext: activeTraceCtx ?? null,
 				...(telemetryTurn !== undefined ? { _telemetryTurn: telemetryTurn } : {}),
-			}
+				...(modelCapabilities?.enableThinking !== undefined ? { _enableThinking: modelCapabilities.enableThinking } : {}),
+			} satisfies ExtensionLanguageModelRequestOptions
 		};
 
 		// Store current CapturingToken for retrieval by BYOK providers after IPC crossing

--- a/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
+++ b/extensions/copilot/src/platform/endpoint/vscode-node/test/extChatEndpoint.spec.ts
@@ -39,6 +39,32 @@ describe('ExtensionContributedChatEndpoint', () => {
 		expect(capturedOptions?.modelOptions?._telemetryTurn).toBe(5);
 	});
 
+	it('issue #330712: forwards the request thinking capability through model options', async () => {
+		const capturedOptions: vscode.LanguageModelChatRequestOptions[] = [];
+		const languageModel = createLanguageModel(options => capturedOptions.push(options));
+		const endpoint = new ExtensionContributedChatEndpoint(
+			languageModel,
+			createInstantiationService(),
+			new NoopOTelService(resolveOTelConfig({ env: {}, extensionVersion: '1.0.0', sessionId: 'test' })),
+		);
+
+		for (const enableThinking of [true, false, undefined]) {
+			await endpoint.makeChatRequest2({
+				debugName: 'test',
+				messages: [{
+					role: Raw.ChatRole.User,
+					content: [{ type: Raw.ChatCompletionContentPartKind.Text, text: 'hello' }]
+				}],
+				finishedCb: undefined,
+				location: ChatLocation.Agent,
+				requestOptions: {},
+				modelCapabilities: enableThinking === undefined ? undefined : { enableThinking },
+			}, new vscode.CancellationTokenSource().token);
+		}
+
+		expect(capturedOptions.map(options => options.modelOptions?._enableThinking)).toEqual([true, false, undefined]);
+	});
+
 	it('only forwards telemetry turn for base-10 non-negative integer request properties', async () => {
 		const capturedOptions: vscode.LanguageModelChatRequestOptions[] = [];
 		const languageModel = createLanguageModel(options => capturedOptions.push(options));


### PR DESCRIPTION
## Summary

- Lets custom endpoint models declare adaptive thinking or bounded thinking-token budgets.
- Preserves request-level thinking enablement across the extension-contributed language model boundary, allowing Messages requests to activate the configured mode.
- Keeps the new capability metadata available across custom endpoint API types while leaving existing Chat Completions and Responses request behavior unchanged.

Fixes #330712

<details>
<summary>Technical context for AI-assisted review</summary>

### Intent and previous behavior

Custom endpoint configuration exposed only the generic `thinking` capability. Messages request construction needs either adaptive-thinking support or minimum and maximum thinking budgets, so neither thinking branch was reachable for configured custom models.

A separate boundary also dropped the per-request `enableThinking` value when an internal endpoint called an extension-contributed language model. Even correctly populated endpoint metadata would therefore reach the BYOK request path without the request-level opt-in.

### Implementation

The custom model schema and shared BYOK capability model now carry adaptive-thinking support and minimum/maximum budgets into `IChatModelInformation`, where `ChatEndpoint` already derives the corresponding endpoint properties.

The extension-contributed endpoint adds the explicit thinking state to its typed internal `modelOptions` payload. `CopilotLanguageModelWrapper` reconstructs that value as `modelCapabilities.enableThinking`, preserving both explicit `true` and explicit `false` across the language model boundary.

Regression coverage traverses configured model discovery, endpoint construction, Messages body generation, and both sides of the internal language model transport.

### Behavior and constraints

- Adaptive thinking takes precedence over budget-based thinking in the existing Messages serializer.
- Budget-based thinking still requires both bounds and retains the existing budget clamping behavior.
- The capability fields are available to all custom endpoint API types, but only the Messages serializer currently consumes them to create a `thinking` body.
- Existing reasoning-effort formatting and non-Messages request bodies remain unchanged.

### Review context

The main review boundary is the internal `modelOptions` contract: it intentionally transports only the request-level boolean and preserves `undefined` when no caller preference exists.

</details>