### PR TITLE
Fix ranges on inline toolset children

### DIFF
--- a/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
+++ b/src/vs/workbench/contrib/chat/common/requestParser/chatRequestParser.ts
@@ -8,6 +8,7 @@ import { IPosition, Position } from '../../../../../editor/common/core/position.
 import { Range } from '../../../../../editor/common/core/range.js';
 import { OffsetRange } from '../../../../../editor/common/core/ranges/offsetRange.js';
 import { IChatVariablesService, IDynamicVariable } from '../attachments/chatVariables.js';
+import { toToolVariableEntry } from '../attachments/chatVariableEntries.js';
 import { ChatAgentLocation, ChatModeKind } from '../constants.js';
 import { getChatSessionType } from '../model/chatUri.js';
 import { IChatAgentAttachmentCapabilities, IChatAgentData, IChatAgentService } from '../participants/chatAgents.js';
@@ -188,7 +189,7 @@ export class ChatRequestParser {
 
 		const toolset = toolSetsByName.get(name);
 		if (toolset) {
-			const value = Array.from(toolset.getTools()).map(t => new ChatRequestToolPart(varRange, varEditorRange, t.toolReferenceName ?? t.displayName, t.id, t.displayName, t.icon).toVariableEntry());
+			const value = Array.from(toolset.getTools()).map(t => toToolVariableEntry(t));
 			return new ChatRequestToolSetPart(varRange, varEditorRange, toolset.id, toolset.referenceName, toolset.icon, value);
 		}
 

--- a/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/requestParser/chatRequestParser.test.ts
@@ -6,6 +6,7 @@
 import { mockObject } from '../../../../../../base/test/common/mock.js';
 import { assertSnapshot } from '../../../../../../base/test/common/snapshot.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
 import { Event } from '../../../../../../base/common/event.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { Range } from '../../../../../../editor/common/core/range.js';
@@ -18,7 +19,7 @@ import { IExtensionService, nullExtensionDescription } from '../../../../../serv
 import { TestExtensionService, TestStorageService } from '../../../../../test/common/workbenchTestServices.js';
 import { ChatAgentService, IChatAgentCommand, IChatAgentData, IChatAgentService } from '../../../common/participants/chatAgents.js';
 import { ChatRequestParser } from '../../../common/requestParser/chatRequestParser.js';
-import { ChatRequestAgentSubcommandPart, ChatRequestDynamicVariablePart, getPromptText } from '../../../common/requestParser/chatParserTypes.js';
+import { ChatRequestAgentSubcommandPart, ChatRequestDynamicVariablePart, ChatRequestToolSetPart, getPromptText } from '../../../common/requestParser/chatParserTypes.js';
 import { IChatService } from '../../../common/chatService/chatService.js';
 import { IChatSlashCommandService } from '../../../common/participants/chatSlashCommands.js';
 import { LocalChatSessionUri } from '../../../common/model/chatUri.js';
@@ -66,6 +67,42 @@ suite('ChatRequestParser', () => {
 		const text = 'line 1\nline 2\r\nline 3';
 		const result = parser.parseChatRequest(testSessionUri, text);
 		await assertSnapshot(result);
+	});
+
+	test('inline toolset keeps the prompt range on the toolset only', () => {
+		const source = ToolDataSource.Internal;
+		const toolSet = new ToolSet(
+			'read',
+			'read',
+			Codicon.book,
+			source,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+			instantiationService.get(IContextKeyService),
+		);
+		testDisposables.add(toolSet.addTool({ id: 'copilot_getNotebookSummary', toolReferenceName: 'getNotebookSummary', canBeReferencedInPrompt: true, displayName: 'getNotebookSummary', modelDescription: '', source }));
+		testDisposables.add(toolSet.addTool({ id: 'copilot_readFile', toolReferenceName: 'readFile', canBeReferencedInPrompt: true, displayName: 'readFile', modelDescription: '', source }));
+		variableService.setSelectedToolAndToolSets(testSessionUri, ToolAndToolSetEnablementMap.fromEntries([[toolSet, true]]));
+
+		parser = instantiationService.createInstance(ChatRequestParser);
+		const result = parser.parseChatRequest(testSessionUri, 'use #read for this');
+		const part = result.parts.find((candidate): candidate is ChatRequestToolSetPart => candidate instanceof ChatRequestToolSetPart);
+
+		assert.deepStrictEqual({
+			promptText: part?.promptText,
+			range: part?.range && { start: part.range.start, endExclusive: part.range.endExclusive },
+			tools: part?.tools.map(tool => ({ id: tool.id, range: tool.range })),
+		}, {
+			promptText: '#read',
+			range: { start: 4, endExclusive: 9 },
+			tools: [
+				{ id: 'copilot_getNotebookSummary', range: undefined },
+				{ id: 'copilot_readFile', range: undefined },
+			],
+		});
 	});
 
 	test('inline attachment reference only preserves reference metadata', () => {


### PR DESCRIPTION
Fixes #330764

## Summary

Inline toolset references currently copy the toolset's prompt range to every expanded child tool. When the extension host flattens those children into model-facing tool references, the first child can appear to be the item explicitly referenced by the user.

For example, an inline `#read` reference can be represented as `copilot_getNotebookSummary`, even though the user selected the whole `read` toolset. MCP server references are affected by the same code path because they are also registered as toolsets.

This change:

- Keeps the prompt range on the explicitly referenced `ChatRequestToolSetPart`.
- Creates its expanded child tool entries without prompt ranges.
- Preserves all child tools as available members of the selected toolset.
- Adds a regression test using the built-in `#read` toolset.

## Testing

Run the focused `ChatRequestParser` unit tests and verify that `inline toolset keeps the prompt range on the toolset only` passes.

The regression test confirms that:

- `#read` retains its prompt text and source range.
- `copilot_getNotebookSummary` and `copilot_readFile` remain attached as child tools.
- Neither child tool inherits the `#read` source range.