### PR TITLE
Add standalone Copilot source build pipeline

### DIFF
--- a/build/azure-pipelines/common/build-copilot-runtime-target.ts
+++ b/build/azure-pipelines/common/build-copilot-runtime-target.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { copilotPlatforms } from '../../lib/copilotPlatforms.ts';
+import { buildRuntimeTarget, isRuntimeSourceActive, runtimeSourceRef, smokeRunPackage } from '../../lib/copilotRuntimeSource.ts';
+
+/**
+ * Builds the `@github/copilot` runtime from source for a single target and
+ * stages it for publishing as a pipeline artifact.
+ *
+ * Entry point for the per-target jobs in `copilot-source-build.yml`.
+ *
+ *   node build/azure-pipelines/common/build-copilot-runtime-target.ts \
+ *     --target=linuxmusl-arm64 --out=<staging dir>
+ *
+ */
+
+function requiredArg(name: string): string {
+	const prefix = `--${name}=`;
+	const value = process.argv.find(arg => arg.startsWith(prefix))?.slice(prefix.length).trim();
+	if (!value) {
+		throw new Error(`[copilot-runtime-build] Missing required argument --${name}=<value>.`);
+	}
+	return value;
+}
+
+function main(): void {
+	const target = requiredArg('target');
+	const outDir = path.resolve(requiredArg('out'));
+	if (!copilotPlatforms.includes(target)) {
+		throw new Error(`[copilot-runtime-build] Unknown target "${target}". Expected one of: ${copilotPlatforms.join(', ')}.`);
+	}
+
+	if (!isRuntimeSourceActive()) {
+		console.log(`[copilot-runtime-build] No runtime source override for this build; skipping ${target}.`);
+		return;
+	}
+
+	const built = buildRuntimeTarget(target);
+	// A package can satisfy every structural assertion and still fail to load.
+	// Catch that here rather than on a user's machine.
+	smokeRunPackage(built, target);
+
+	fs.rmSync(outDir, { recursive: true, force: true });
+	fs.mkdirSync(outDir, { recursive: true });
+	fs.cpSync(built, outDir, { recursive: true });
+
+	// Gates the publish step: the artifact only exists when this build actually
+	// produced one.
+	console.log(`##vso[task.setvariable variable=COPILOT_RUNTIME_ARTIFACT_READY]true`);
+	console.log(`[copilot-runtime-build] Staged ${target} (${runtimeSourceRef()}) at ${outDir}`);
+}
+
+main();

--- a/build/azure-pipelines/common/buildCopilotOverride.ts
+++ b/build/azure-pipelines/common/buildCopilotOverride.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { sourceBuildVersion, type CopilotGitSource } from './copilotSource.ts';
+import { gitAuthArgs, gitEnv, redactedError, redactSecrets, withGitHubRetries } from '../../lib/copilotRuntimeSource.ts';
+
+/**
+ * Builds the Copilot SDK from a source commit and returns a publishable tarball.
+ */
+
+const ROOT = path.join(import.meta.dirname, '../../../');
+
+/** Where clones + build outputs live; git-ignored, cache-key neutral. */
+export const OVERRIDES_DIR = path.join(ROOT, '.build', 'copilot-overrides');
+
+const IS_WINDOWS = process.platform === 'win32';
+const NPM = IS_WINDOWS ? 'npm.cmd' : 'npm';
+
+function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): void {
+	console.log(`[copilot-override] $ ${command} ${redactSecrets(args.join(' '))}  (cwd: ${cwd})`);
+	// Only `.cmd`/`.bat` shims need a shell; git/node must not use one, or spaced
+	// args (e.g. the http.extraheader auth header) get split on Windows.
+	const shell = IS_WINDOWS && /\.(cmd|bat)$/i.test(command);
+	try {
+		execFileSync(command, args, { cwd, stdio: 'inherit', shell, env });
+	} catch (err) {
+		throw redactedError(err);
+	}
+}
+
+/**
+ * Fetches `owner/name` at commit `sha` into `dest` (shallow, single commit).
+ * Assumes public repos; an optional `COPILOT_OVERRIDE_TOKEN` / `GITHUB_TOKEN`
+ * authenticates a private fetch via `http.extraheader`, keeping the token out of
+ * the URL, `.git/config` and (redacted) logs.
+ */
+function cloneRepo(repo: string, sha: string, dest: string): void {
+	fs.rmSync(dest, { recursive: true, force: true });
+	fs.mkdirSync(dest, { recursive: true });
+
+	const token = (process.env['COPILOT_OVERRIDE_TOKEN'] ?? process.env['GITHUB_TOKEN'] ?? '').trim();
+	const authArgs = gitAuthArgs(token || undefined);
+	const url = `https://github.com/${repo}.git`;
+
+	// Fetch just the pinned commit (GitHub allows fetching a reachable SHA), then
+	// check it out. Falls back to a full fetch if the shallow SHA fetch is refused.
+	run('git', ['init', '-q'], dest);
+	run('git', ['remote', 'add', 'origin', url], dest);
+	// Every node_modules and compile job builds its own tarball, so one transient
+	// GitHub failure anywhere fails the build.
+	withGitHubRetries(`fetch ${repo}@${sha}`, () => {
+		try {
+			run('git', [...authArgs, 'fetch', '--depth', '1', 'origin', sha], dest, gitEnv());
+		} catch {
+			console.log(`[copilot-override] Shallow fetch of ${repo}@${sha} failed; retrying with a full fetch.`);
+			run('git', [...authArgs, 'fetch', 'origin'], dest, gitEnv());
+		}
+	});
+	run('git', ['checkout', '-q', sha], dest);
+	console.log(`[copilot-override] Checked out ${repo}@${sha} -> ${dest}`);
+}
+
+/**
+ * Builds `@github/copilot-sdk` from source and returns the absolute path to a
+ * packed `.tgz`. Pure TypeScript: install dev deps (ignoring native lifecycle
+ * scripts), run the package's own esbuild + `tsc`, then `npm pack`.
+ */
+export function buildSdkTarball(source: CopilotGitSource, options: { version?: string; runtimeVersion?: string } = {}): string {
+	const srcDir = path.join(OVERRIDES_DIR, 'sdk-src');
+	cloneRepo(source.repo, source.ref, srcDir);
+
+	// The publishable package lives in the `nodejs/` workspace of copilot-sdk.
+	const pkgDir = path.join(srcDir, 'nodejs');
+	if (!fs.existsSync(path.join(pkgDir, 'package.json'))) {
+		throw new Error(`[copilot-override] Expected SDK package at ${pkgDir} (nodejs/ workspace not found in ${source.repo}@${source.ref}).`);
+	}
+
+	run(NPM, ['ci', '--ignore-scripts', '--no-audit', '--no-fund'], pkgDir);
+	run(NPM, ['run', 'build'], pkgDir);
+
+	// Stamp after building and before packing, mirroring the SDK's own `package`
+	// script. The in-repo manifest carries a fixed `0.0.0-dev`, so without this
+	// every commit packs to the same filename — see `sourceBuildVersion`.
+	const version = options.version ?? sourceBuildVersion(source.ref);
+	stampVersion(pkgDir, version, options.runtimeVersion);
+
+	const outDir = path.join(OVERRIDES_DIR, 'sdk-pack');
+	fs.rmSync(outDir, { recursive: true, force: true });
+	fs.mkdirSync(outDir, { recursive: true });
+	run(NPM, ['pack', '--pack-destination', outDir], pkgDir);
+
+	const tarball = fs.readdirSync(outDir).find(name => name.endsWith('.tgz'));
+	if (!tarball) {
+		throw new Error(`[copilot-override] npm pack produced no tarball for SDK in ${outDir}.`);
+	}
+	if (!tarball.includes(version)) {
+		throw new Error(`[copilot-override] Packed SDK tarball "${tarball}" does not carry the stamped version ${version}, so the node_modules cache key cannot distinguish SDK commits.`);
+	}
+	const tarballPath = path.join(outDir, tarball);
+	console.log(`[copilot-override] Built SDK tarball ${tarballPath} from ${source.repo}@${source.ref}`);
+	return tarballPath;
+}
+
+/** Rewrites the package version so the packed tarball name is commit-unique. */
+function stampVersion(pkgDir: string, version: string, runtimeVersion?: string): void {
+	const manifestPath = path.join(pkgDir, 'package.json');
+	const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+	manifest.version = version;
+	if (runtimeVersion) {
+		manifest.dependencies ??= {};
+		manifest.dependencies['@github/copilot'] = runtimeVersion;
+	}
+	fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+}

--- a/build/azure-pipelines/common/copilotSource.ts
+++ b/build/azure-pipelines/common/copilotSource.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const RUNTIME_REPO = 'github/copilot-agent-runtime';
+
+export interface CopilotGitSource {
+	readonly repo: string;
+	readonly ref: string;
+}
+
+export function sourceBuildVersion(ref: string): string {
+	return `0.0.0-src.g${ref.slice(0, 7)}`;
+}

--- a/build/azure-pipelines/common/copilotSourcePublish.ts
+++ b/build/azure-pipelines/common/copilotSourcePublish.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { copilotPlatforms } from '../../lib/copilotPlatforms.ts';
+import { runtimeArtifactName } from '../../lib/copilotRuntimeSource.ts';
+
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const SOURCE_VERSION = /^\d+\.\d+\.\d+-[0-9A-Za-z]+(?:[0-9A-Za-z.-]*[0-9A-Za-z])?$/;
+
+interface PackageManifest {
+	name: string;
+	version: string;
+	description?: string;
+	license?: string;
+	type?: string;
+	repository?: object;
+	bugs?: object;
+	homepage?: string;
+	author?: string;
+	bin?: Record<string, string>;
+	dependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	files?: string[];
+	exports?: Record<string, string | Record<string, string>>;
+	os?: string[];
+	cpu?: string[];
+	libc?: string[];
+}
+
+export function assertSourceVersion(version: string): void {
+	if (!SOURCE_VERSION.test(version)) {
+		throw new Error(`[copilot-source-publish] Invalid source package version "${version}". Expected a semver prerelease.`);
+	}
+}
+
+function readManifest(dir: string): PackageManifest {
+	const manifestPath = path.join(dir, 'package.json');
+	if (!fs.existsSync(manifestPath)) {
+		throw new Error(`[copilot-source-publish] Missing package.json in ${dir}.`);
+	}
+	return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as PackageManifest;
+}
+
+function writeManifest(dir: string, manifest: PackageManifest): void {
+	fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(manifest, null, 2) + '\n');
+}
+
+function targetMetadata(target: string): { platform: string; arch: string; os: string; libc?: string } {
+	const separator = target.lastIndexOf('-');
+	const platform = target.slice(0, separator);
+	const arch = target.slice(separator + 1);
+	return {
+		platform,
+		arch,
+		os: platform === 'linuxmusl' ? 'linux' : platform,
+		libc: platform === 'linux' ? 'glibc' : platform === 'linuxmusl' ? 'musl' : undefined,
+	};
+}
+
+function assertRuntimePackage(dir: string, target: string): void {
+	for (const relativePath of ['index.js', 'npm-loader.js', 'sdk/index.js', 'sdk/index.d.ts', '.copilot-source-complete']) {
+		if (!fs.existsSync(path.join(dir, relativePath))) {
+			throw new Error(`[copilot-source-publish] ${runtimeArtifactName(target)} is incomplete: missing ${relativePath}.`);
+		}
+	}
+}
+
+/**
+ * Converts the eight target artifacts into the package layout consumed by npm:
+ * one thin `@github/copilot` loader plus one full JS/native package per target.
+ */
+export function assembleRuntimePackages(artifactsDir: string, outputDir: string, version: string): string[] {
+	assertSourceVersion(version);
+	fs.rmSync(outputDir, { recursive: true, force: true });
+	fs.mkdirSync(outputDir, { recursive: true });
+
+	const optionalDependencies: Record<string, string> = {};
+	let mainSource: string | undefined;
+	const packageDirs: string[] = [];
+
+	for (const target of copilotPlatforms) {
+		const artifactDir = path.join(artifactsDir, runtimeArtifactName(target));
+		assertRuntimePackage(artifactDir, target);
+		mainSource ??= artifactDir;
+
+		const packageDir = path.join(outputDir, target);
+		fs.cpSync(artifactDir, packageDir, { recursive: true });
+		fs.rmSync(path.join(packageDir, '.copilot-source-complete'), { force: true });
+
+		const { arch, os, libc } = targetMetadata(target);
+		const packageName = `@github/copilot-${target}`;
+		const sourceManifest = readManifest(packageDir);
+		const manifest: PackageManifest = {
+			name: packageName,
+			version,
+			description: `GitHub Copilot CLI runtime for ${target}`,
+			license: sourceManifest.license,
+			type: sourceManifest.type,
+			repository: sourceManifest.repository,
+			bugs: sourceManifest.bugs,
+			homepage: sourceManifest.homepage,
+			os: [os],
+			cpu: [arch],
+			exports: {
+				'.': './index.js',
+				'./sdk': {
+					types: './sdk/index.d.ts',
+					import: './sdk/index.js',
+				},
+			},
+			files: sourceManifest.files,
+		};
+		if (libc) {
+			manifest.libc = [libc];
+		}
+		writeManifest(packageDir, manifest);
+		optionalDependencies[packageName] = version;
+		packageDirs.push(packageDir);
+	}
+
+	if (!mainSource) {
+		throw new Error('[copilot-source-publish] No runtime artifacts were assembled.');
+	}
+
+	const mainDir = path.join(outputDir, 'copilot');
+	fs.mkdirSync(mainDir, { recursive: true });
+	for (const file of ['npm-loader.js', 'README.md', 'LICENSE.md']) {
+		const source = path.join(mainSource, file);
+		if (fs.existsSync(source)) {
+			fs.copyFileSync(source, path.join(mainDir, file));
+		}
+	}
+	const sourceManifest = readManifest(mainSource);
+	writeManifest(mainDir, {
+		name: '@github/copilot',
+		version,
+		description: sourceManifest.description,
+		license: sourceManifest.license,
+		type: sourceManifest.type,
+		repository: sourceManifest.repository,
+		bugs: sourceManifest.bugs,
+		homepage: sourceManifest.homepage,
+		author: sourceManifest.author,
+		bin: { copilot: 'npm-loader.js' },
+		dependencies: sourceManifest.dependencies,
+		optionalDependencies,
+		files: ['npm-loader.js', 'README.md', 'LICENSE.md'],
+	});
+
+	return [...packageDirs, mainDir];
+}
+
+function runNpm(args: string[], cwd?: string): { status: number; output: string } {
+	const result = spawnSync(NPM, args, {
+		cwd,
+		encoding: 'utf8',
+		shell: process.platform === 'win32',
+	});
+	const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+	if (result.error) {
+		throw result.error;
+	}
+	return { status: result.status ?? 1, output };
+}
+
+function packageExists(name: string, version: string, registry: string): boolean {
+	const result = runNpm(['view', `${name}@${version}`, 'version', '--registry', registry]);
+	if (result.status === 0) {
+		return result.output.trim().replace(/^"|"$/g, '') === version;
+	}
+	if (/\bE404\b|404 Not Found|is not in this registry/i.test(result.output)) {
+		return false;
+	}
+	throw new Error(`[copilot-source-publish] Failed to query ${name}@${version}:\n${result.output}`);
+}
+
+export function publishPackage(packagePath: string, registry: string, tag = 'vscode-source', identity?: { name: string; version: string }): void {
+	const packageDirectory = fs.statSync(packagePath).isDirectory() ? packagePath : undefined;
+	const { name, version } = identity ?? readManifest(packageDirectory!);
+	if (packageExists(name, version, registry)) {
+		console.log(`[copilot-source-publish] ${name}@${version} already exists; skipping.`);
+		return;
+	}
+
+	const result = runNpm(['publish', packagePath, '--tag', tag, '--access', 'restricted', '--registry', registry]);
+	if (result.status !== 0) {
+		throw new Error(`[copilot-source-publish] Failed to publish ${name}@${version}:\n${result.output}`);
+	}
+	console.log(result.output);
+	console.log(`[copilot-source-publish] Published ${name}@${version}.`);
+}

--- a/build/azure-pipelines/common/install-runtime-build-toolchain.ts
+++ b/build/azure-pipelines/common/install-runtime-build-toolchain.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Installs the Rust toolchain needed to build `@github/copilot` from source.
+ *
+ * The runtime's own `build-runtime.ts` runs `rustup target add <triple>` for the
+ * requested target, so the essential prerequisite here is `rustup` itself. Cross
+ * targets additionally need per-platform system tooling (musl/cross-arch), which
+ * this best-effort provisions; a given CI image may already ship some of it.
+ */
+
+const IS_WINDOWS = process.platform === 'win32';
+
+function tryRun(command: string, args: string[], opts: { env?: NodeJS.ProcessEnv } = {}): boolean {
+	try {
+		console.log(`[runtime-toolchain] $ ${command} ${args.join(' ')}`);
+		// These are all real executables (no `.cmd` shims), so never use a shell —
+		// on Windows a shell would split spaced args like the PowerShell -Command.
+		execFileSync(command, args, { stdio: 'inherit', shell: false, env: opts.env ?? process.env });
+		return true;
+	} catch (err) {
+		console.warn(`[runtime-toolchain] command failed: ${err instanceof Error ? err.message : String(err)}`);
+		return false;
+	}
+}
+
+function has(command: string): boolean {
+	try {
+		execFileSync(IS_WINDOWS ? 'where' : 'which', [command], { stdio: 'ignore', shell: false });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function ensureRustup(): void {
+	if (has('rustup')) {
+		console.log('[runtime-toolchain] rustup already present.');
+		tryRun('rustup', ['--version']);
+		return;
+	}
+	console.log('[runtime-toolchain] rustup not found — installing.');
+	const cargoBin = path.join(os.homedir(), '.cargo', 'bin');
+	if (IS_WINDOWS) {
+		// Download and run rustup-init non-interactively.
+		tryRun('powershell', ['-NoProfile', '-Command',
+			'Invoke-WebRequest https://win.rustup.rs/x86_64 -OutFile rustup-init.exe; ./rustup-init.exe -y --default-toolchain stable --profile minimal']);
+	} else {
+		tryRun('sh', ['-c', 'curl --proto \'=https\' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal']);
+	}
+
+	// Verify the binary on disk rather than via PATH: `prependpath` only affects
+	// later steps, not this process. Unlike the cross tooling below, a missing
+	// rustup is unrecoverable, and letting it slide turns into an opaque cargo
+	// failure deep inside gulp packaging instead of a clear error here.
+	const rustup = path.join(cargoBin, IS_WINDOWS ? 'rustup.exe' : 'rustup');
+	if (!fs.existsSync(rustup)) {
+		throw new Error(`[runtime-toolchain] rustup installation failed: ${rustup} not found. A runtime source build cannot proceed without it.`);
+	}
+	console.log(`##vso[task.prependpath]${cargoBin}`);
+}
+
+/**
+ * Best-effort cross-compilation tooling. Native (host-arch, host-libc) builds
+ * need none of this; it only matters when a job cross-builds a slice of the
+ * matrix (e.g. linux musl/arm64 in the Linux job). Failures are non-fatal here —
+ * `build-runtime.ts` surfaces a precise error if a required tool is missing.
+ */
+function ensureCrossTooling(): void {
+	// cargo-zigbuild routes musl and Linux cross-compiles through zig.
+	if (!has('cargo-zigbuild')) {
+		tryRun('cargo', ['install', '--locked', 'cargo-zigbuild']);
+	}
+	// zig itself (cargo-zigbuild dependency).
+	if (!has('zig')) {
+		if (process.platform === 'darwin') {
+			tryRun('brew', ['install', 'zig']);
+		} else if (process.platform === 'linux') {
+			// pip's ziglang wheel provides a `zig`-compatible entry point without root.
+			tryRun('python3', ['-m', 'pip', 'install', '--user', 'ziglang']);
+		}
+	}
+	// Linux glibc arm64 cross needs the GNU cross toolchain.
+	if (process.platform === 'linux') {
+		tryRun('sh', ['-c', 'command -v apt-get >/dev/null 2>&1 && sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu || true']);
+	}
+}
+
+function main(): void {
+	console.log(`[runtime-toolchain] Provisioning Rust build toolchain on ${process.platform}.`);
+	ensureRustup();
+	ensureCrossTooling();
+	console.log('[runtime-toolchain] Done. build-runtime.ts will add the specific rustup target(s) per build.');
+}
+
+main();

--- a/build/azure-pipelines/common/mintGithubAppToken.ts
+++ b/build/azure-pipelines/common/mintGithubAppToken.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as crypto from 'crypto';
+import * as https from 'https';
+
+/**
+ * Mints a short-lived GitHub App installation token so a runtime `git:<ref>`
+ * source build can clone the private `github/copilot-agent-runtime` repo. Mirrors
+ * the JWT + installation-token flow used by
+ * `build/azure-pipelines/github-check-run.js`.
+ *
+ * The `copilot-agent-runtime` GitHub App:
+ *   App ID  4297675
+ *   Secret  vscode-build-secrets / copilot-agent-runtime-gh-app (private key PEM)
+ */
+
+/** Default App ID for the `copilot-agent-runtime` GitHub App. */
+export const COPILOT_APP_ID = '4297675';
+
+/**
+ * Mints a clone token from the App key in the environment, or returns undefined
+ * when there is none. The key arrives as the literal `$(...)` macro when the
+ * gated Key Vault step did not run — treat that (and empty) as "no key", leaving
+ * an explicit `COPILOT_OVERRIDE_TOKEN` or a public clone to cover local runs.
+ */
+export async function mintCloneTokenFromEnv(repo: string, env: NodeJS.ProcessEnv = process.env): Promise<string | undefined> {
+	const privateKey = (env['GITHUB_APP_PRIVATE_KEY'] ?? '').trim();
+	if (!privateKey || privateKey.startsWith('$(')) {
+		return undefined;
+	}
+	const appId = (env['GITHUB_APP_ID'] ?? COPILOT_APP_ID).trim();
+	const [owner, name] = repo.split('/');
+	console.log(`[copilot-override] Minting GitHub App installation token (app ${appId}) for ${repo}.`);
+	return mintInstallationToken(appId, privateKey, owner, name);
+}
+
+function createJwt(appId: string, privateKey: string): string {
+	const now = Math.floor(Date.now() / 1000);
+	const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+	// `iat` backdated 60s for clock skew; `exp` is the 10 min JWT max.
+	const payload = Buffer.from(JSON.stringify({ iat: now - 60, exp: now + 600, iss: appId })).toString('base64url');
+	const signature = crypto.sign('sha256', Buffer.from(`${header}.${payload}`), privateKey).toString('base64url');
+	return `${header}.${payload}.${signature}`;
+}
+
+function request(options: https.RequestOptions, body?: object): Promise<any> {
+	return new Promise((resolve, reject) => {
+		const req = https.request(options, res => {
+			let data = '';
+			res.on('data', chunk => data += chunk);
+			res.on('end', () => {
+				if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+					resolve(data ? JSON.parse(data) : {});
+				} else {
+					reject(new Error(`HTTP ${res.statusCode}: ${data}`));
+				}
+			});
+		});
+		req.on('error', reject);
+		if (body) {
+			req.write(JSON.stringify(body));
+		}
+		req.end();
+	});
+}
+
+const ghHeaders = (auth: string): https.RequestOptions['headers'] => ({
+	'Authorization': auth,
+	'Accept': 'application/vnd.github+json',
+	'User-Agent': 'VSCode-ADO-Pipeline',
+	'X-GitHub-Api-Version': '2022-11-28',
+});
+
+/**
+ * Mints an installation token scoped to `owner/repo` with `contents:read` — the
+ * least privilege needed to clone it. Normalizes `\n`-escaped PEM keys.
+ */
+export async function mintInstallationToken(appId: string, privateKey: string, owner: string, repo: string): Promise<string> {
+	const jwt = createJwt(appId, privateKey.includes('\\n') ? privateKey.replace(/\\n/g, '\n') : privateKey);
+
+	const installation: { id: number } = await request({
+		hostname: 'api.github.com',
+		path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/installation`,
+		method: 'GET',
+		headers: ghHeaders(`Bearer ${jwt}`),
+	});
+
+	const result: { token: string } = await request({
+		hostname: 'api.github.com',
+		path: `/app/installations/${installation.id}/access_tokens`,
+		method: 'POST',
+		headers: ghHeaders(`Bearer ${jwt}`),
+	}, { repositories: [repo], permissions: { contents: 'read' } });
+
+	return result.token;
+}

--- a/build/azure-pipelines/common/prepare-copilot-runtime-source.ts
+++ b/build/azure-pipelines/common/prepare-copilot-runtime-source.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RUNTIME_REPO } from './copilotSource.ts';
+import { mintCloneTokenFromEnv } from './mintGithubAppToken.ts';
+import { writeRuntimeSourceMarker, writeRuntimeToken } from '../../lib/copilotRuntimeSource.ts';
+
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+
+async function main(): Promise<void> {
+	const ref = (process.env['COPILOT_RUNTIME_SOURCE_REF'] ?? '').trim();
+	if (!COMMIT_SHA.test(ref)) {
+		throw new Error('[copilot-runtime-source] COPILOT_RUNTIME_SOURCE_REF must be a full 40-character lowercase commit SHA.');
+	}
+
+	const token = await mintCloneTokenFromEnv(RUNTIME_REPO);
+	if (!token) {
+		throw new Error('[copilot-runtime-source] The GitHub App key did not produce a clone token.');
+	}
+
+	writeRuntimeSourceMarker(RUNTIME_REPO, ref);
+	writeRuntimeToken(token);
+	console.log(`##vso[build.addbuildtag]copilot-runtime=git.${ref}`);
+	console.log(`[copilot-runtime-source] Prepared ${RUNTIME_REPO}@${ref}.`);
+}
+
+main().catch(error => {
+	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+	process.exit(1);
+});

--- a/build/azure-pipelines/common/publish-copilot-runtime.ts
+++ b/build/azure-pipelines/common/publish-copilot-runtime.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import { assembleRuntimePackages, publishPackage } from './copilotSourcePublish.ts';
+
+function requiredEnv(name: string): string {
+	const value = process.env[name]?.trim();
+	if (!value) {
+		throw new Error(`[copilot-source-publish] Missing required environment variable ${name}.`);
+	}
+	return value;
+}
+
+const artifactsDir = path.resolve(requiredEnv('COPILOT_RUNTIME_ARTIFACTS_DIR'));
+const outputDir = path.resolve(requiredEnv('COPILOT_RUNTIME_PACKAGES_DIR'));
+const version = requiredEnv('COPILOT_SOURCE_VERSION');
+const registry = requiredEnv('COPILOT_SOURCE_REGISTRY');
+
+for (const packageDir of assembleRuntimePackages(artifactsDir, outputDir, version)) {
+	publishPackage(packageDir, registry);
+}

--- a/build/azure-pipelines/common/publish-copilot-sdk.ts
+++ b/build/azure-pipelines/common/publish-copilot-sdk.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { buildSdkTarball } from './buildCopilotOverride.ts';
+import { assertSourceVersion, publishPackage } from './copilotSourcePublish.ts';
+
+function requiredEnv(name: string): string {
+	const value = process.env[name]?.trim();
+	if (!value) {
+		throw new Error(`[copilot-source-publish] Missing required environment variable ${name}.`);
+	}
+	return value;
+}
+
+const ref = requiredEnv('COPILOT_SDK_SOURCE_REF');
+const version = requiredEnv('COPILOT_SOURCE_VERSION');
+const runtimeVersion = requiredEnv('COPILOT_RUNTIME_SOURCE_VERSION');
+const registry = requiredEnv('COPILOT_SOURCE_REGISTRY');
+assertSourceVersion(version);
+assertSourceVersion(runtimeVersion);
+
+const source = {
+	repo: 'github/copilot-sdk',
+	ref,
+};
+
+const tarball = buildSdkTarball(source, { version, runtimeVersion });
+publishPackage(tarball, registry, 'vscode-source', { name: '@github/copilot-sdk', version });

--- a/build/azure-pipelines/common/queue-copilot-product-build.ts
+++ b/build/azure-pipelines/common/queue-copilot-product-build.ts
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+interface ProductBuildRequest {
+	readonly definition: { readonly id: number };
+	readonly sourceBranch: string;
+	readonly templateParameters: {
+		readonly VSCODE_QUALITY: string;
+		readonly NPM_REGISTRY: string;
+		readonly VSCODE_SDK_CANARY_VERSION: string;
+		readonly VSCODE_CLI_CANARY_VERSION: string;
+		readonly VSCODE_PUBLISH: boolean;
+		readonly VSCODE_RELEASE: boolean;
+	};
+}
+
+interface BuildResponse {
+	readonly id: number;
+	readonly buildNumber: string;
+	readonly status: string;
+	readonly result?: string;
+	readonly _links?: { readonly web?: { readonly href?: string } };
+}
+
+interface QueueOptions {
+	readonly definitionId: number;
+	readonly sourceBranch: string;
+	readonly quality: string;
+	readonly registry: string;
+	readonly sdkVersion: string;
+	readonly runtimeVersion: string;
+	readonly publish: boolean;
+	readonly release: boolean;
+}
+
+function requiredEnv(name: string): string {
+	const value = (process.env[name] ?? '').trim();
+	if (!value) {
+		throw new Error(`[copilot-product-build] Missing required environment variable ${name}.`);
+	}
+	return value;
+}
+
+function booleanEnv(name: string, defaultValue: boolean): boolean {
+	const value = (process.env[name] ?? '').trim().toLowerCase();
+	if (!value) {
+		return defaultValue;
+	}
+	if (value !== 'true' && value !== 'false') {
+		throw new Error(`[copilot-product-build] ${name} must be true or false.`);
+	}
+	return value === 'true';
+}
+
+function sourceBranch(ref: string): string {
+	return ref.startsWith('refs/') ? ref : `refs/heads/${ref}`;
+}
+
+export function createProductBuildRequest(options: QueueOptions): ProductBuildRequest {
+	return {
+		definition: { id: options.definitionId },
+		sourceBranch: sourceBranch(options.sourceBranch),
+		templateParameters: {
+			VSCODE_QUALITY: options.quality,
+			NPM_REGISTRY: options.registry,
+			VSCODE_SDK_CANARY_VERSION: options.sdkVersion,
+			VSCODE_CLI_CANARY_VERSION: options.runtimeVersion,
+			VSCODE_PUBLISH: options.publish,
+			VSCODE_RELEASE: options.release,
+		},
+	};
+}
+
+async function adoRequest<T>(url: string, token: string, init: RequestInit = {}): Promise<T> {
+	const response = await fetch(url, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+			...init.headers,
+		},
+	});
+	const body = await response.text();
+	if (!response.ok) {
+		throw new Error(`[copilot-product-build] Azure DevOps request failed (${response.status} ${response.statusText}): ${body}`);
+	}
+	return JSON.parse(body) as T;
+}
+
+async function waitForBuild(url: string, token: string, build: BuildResponse): Promise<void> {
+	const deadline = Date.now() + 8 * 60 * 60 * 1000;
+	let current = build;
+	while (current.status !== 'completed') {
+		if (Date.now() >= deadline) {
+			throw new Error(`[copilot-product-build] Timed out waiting for child build ${current.id}.`);
+		}
+		await new Promise(resolve => setTimeout(resolve, 30_000));
+		current = await adoRequest<BuildResponse>(`${url}/${current.id}?api-version=7.1`, token);
+		console.log(`[copilot-product-build] Child build ${current.id}: ${current.status}${current.result ? ` (${current.result})` : ''}.`);
+	}
+	if (current.result !== 'succeeded') {
+		throw new Error(`[copilot-product-build] Child build ${current.id} completed with result ${current.result ?? 'unknown'}.`);
+	}
+}
+
+async function main(): Promise<void> {
+	const collectionUri = requiredEnv('SYSTEM_COLLECTIONURI').replace(/\/?$/, '/');
+	const project = encodeURIComponent(requiredEnv('SYSTEM_TEAMPROJECT'));
+	const token = requiredEnv('SYSTEM_ACCESSTOKEN');
+	const definitionId = Number(requiredEnv('VSCODE_PRODUCT_BUILD_DEFINITION_ID'));
+	if (!Number.isInteger(definitionId) || definitionId <= 0) {
+		throw new Error('[copilot-product-build] VSCODE_PRODUCT_BUILD_DEFINITION_ID must be a positive integer.');
+	}
+
+	const request = createProductBuildRequest({
+		definitionId,
+		sourceBranch: requiredEnv('VSCODE_PRODUCT_SOURCE_BRANCH'),
+		quality: requiredEnv('VSCODE_QUALITY'),
+		registry: requiredEnv('NPM_REGISTRY'),
+		sdkVersion: requiredEnv('COPILOT_SDK_SOURCE_VERSION'),
+		runtimeVersion: requiredEnv('COPILOT_RUNTIME_SOURCE_VERSION'),
+		publish: booleanEnv('VSCODE_PUBLISH', false),
+		release: booleanEnv('VSCODE_RELEASE', false),
+	});
+	const buildsUrl = `${collectionUri}${project}/_apis/build/builds`;
+	const build = await adoRequest<BuildResponse>(`${buildsUrl}?api-version=7.1`, token, {
+		method: 'POST',
+		body: JSON.stringify(request),
+	});
+	const webUrl = build._links?.web?.href;
+	console.log(`##vso[build.addbuildtag]product-build=${build.id}`);
+	console.log(`[copilot-product-build] Queued child build ${build.buildNumber} (${build.id})${webUrl ? `: ${webUrl}` : '.'}`);
+
+	if (booleanEnv('VSCODE_WAIT_FOR_PRODUCT_BUILD', true)) {
+		await waitForBuild(buildsUrl, token, build);
+	}
+}
+
+if (import.meta.main) {
+	main().catch(error => {
+		console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+		process.exit(1);
+	});
+}

--- a/build/azure-pipelines/copilot-source-build.yml
+++ b/build/azure-pipelines/copilot-source-build.yml
@@ -1,0 +1,178 @@
+pr: none
+
+trigger: none
+
+parameters:
+  - name: COPILOT_SDK_SOURCE_REF
+    displayName: Copilot SDK Commit
+    type: string
+  - name: COPILOT_RUNTIME_SOURCE_REF
+    displayName: Copilot Runtime Commit
+    type: string
+  - name: VSCODE_PRODUCT_SOURCE_BRANCH
+    displayName: VS Code Branch for Product Build
+    type: string
+    default: main
+  - name: VSCODE_QUALITY
+    displayName: Product Build Quality
+    type: string
+    default: insider
+    values:
+      - exploration
+      - insider
+      - stable
+  - name: VSCODE_PUBLISH
+    displayName: Publish Product Build
+    type: boolean
+    default: false
+  - name: VSCODE_RELEASE
+    displayName: Release Product Build
+    type: boolean
+    default: false
+  - name: VSCODE_WAIT_FOR_PRODUCT_BUILD
+    displayName: Wait for Product Build
+    type: boolean
+    default: true
+  - name: NPM_REGISTRY
+    displayName: Internal NPM Registry
+    type: string
+    default: https://pkgs.dev.azure.com/monacotools/Monaco/_packaging/vscode/npm/registry/
+  - name: VSCODE_PRODUCT_BUILD_DEFINITION_ID
+    displayName: Product Build Definition
+    type: number
+    default: 111
+
+variables:
+  - name: skipComponentGovernanceDetection
+    value: true
+  - name: Codeql.SkipTaskAutoInjection
+    value: true
+  - name: NPM_REGISTRY
+    value: ${{ parameters.NPM_REGISTRY }}
+  - name: COPILOT_SOURCE_VERSION
+    value: 0.0.0-vscode.$(Build.BuildId)
+
+name: "$(Date:yyyyMMdd).$(Rev:r) (Copilot source)"
+
+resources:
+  repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      tsa:
+        enabled: false
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: The pipeline builds external Copilot sources and does not compile VS Code.
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)/build/azure-pipelines/config/CredScanSuppressions.json
+      eslint:
+        enabled: false
+      sourceAnalysisPool: 1es-windows-2022-x64
+      createAdoIssuesForJustificationsForDisablement: false
+    stages:
+      - stage: Build
+        displayName: Build Copilot Runtime
+        jobs:
+          - template: build/azure-pipelines/copilot/source-publish-runtime-job.yml@self
+            parameters:
+              target: win32-x64
+              sourceRef: ${{ parameters.COPILOT_RUNTIME_SOURCE_REF }}
+          - template: build/azure-pipelines/copilot/source-publish-runtime-job.yml@self
+            parameters:
+              target: win32-arm64
+              sourceRef: ${{ parameters.COPILOT_RUNTIME_SOURCE_REF }}
+          - template: build/azure-pipelines/copilot/source-publish-runtime-job.yml@self
+            parameters:
+              target: linux-x64
+              sourceRef: ${{ parameters.COPILOT_RUNTIME_SOURCE_REF }}
+          - template: build/azure-pipelines/copilot/source-publish-runtime-job.yml@self
+            parameters:
+              target: linux-arm64
+              sourceRef: ${{ parameters.COPILOT_RUNTIME_SOURCE_REF }}
+          - template: build/azure-pipelines/copilot/source-publish-runtime-job.yml@self
+            parameters:
+              target: linuxmusl-x64
+              sourceRef: ${{ parameters.COPILOT_RUNTIME_SOURCE_REF }}
+          - template: build/azure-pipelines/copilot/source-publish-runtime-job.yml@self
+            parameters:
+              target: linuxmusl-arm64
+              sourceRef: ${{ parameters.COPILOT_RUNTIME_SOURCE_REF }}
+          - template: build/azure-pipelines/copilot/source-publish-runtime-job.yml@self
+            parameters:
+              target: darwin-x64
+              sourceRef: ${{ parameters.COPILOT_RUNTIME_SOURCE_REF }}
+          - template: build/azure-pipelines/copilot/source-publish-runtime-job.yml@self
+            parameters:
+              target: darwin-arm64
+              sourceRef: ${{ parameters.COPILOT_RUNTIME_SOURCE_REF }}
+
+      - stage: Publish
+        displayName: Publish and Queue Product Build
+        dependsOn: Build
+        pool:
+          name: 1es-ubuntu-22.04-x64
+          os: linux
+        jobs:
+          - job: Publish
+            timeoutInMinutes: 600
+            steps:
+              - template: build/azure-pipelines/common/checkout.yml@self
+
+              - task: NodeTool@0
+                inputs:
+                  versionSource: fromFile
+                  versionFilePath: .nvmrc
+
+              - download: current
+                patterns: copilot_runtime_*/**
+                displayName: Download runtime artifacts
+
+              - script: |
+                  set -e
+                  printf 'registry=%s\nalways-auth=true\n' "$NPM_REGISTRY" > "$(Agent.TempDirectory)/copilot-source.npmrc"
+                displayName: Configure internal NPM feed
+
+              - task: npmAuthenticate@0
+                inputs:
+                  workingFile: $(Agent.TempDirectory)/copilot-source.npmrc
+                displayName: Authenticate internal NPM feed
+
+              - script: node build/azure-pipelines/common/publish-copilot-runtime.ts
+                env:
+                  COPILOT_RUNTIME_ARTIFACTS_DIR: $(Pipeline.Workspace)
+                  COPILOT_RUNTIME_PACKAGES_DIR: $(Build.ArtifactStagingDirectory)/copilot-runtime-packages
+                  COPILOT_SOURCE_VERSION: $(COPILOT_SOURCE_VERSION)
+                  COPILOT_SOURCE_REGISTRY: $(NPM_REGISTRY)
+                  NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/copilot-source.npmrc
+                displayName: Publish Copilot runtime packages
+
+              - script: node build/azure-pipelines/common/publish-copilot-sdk.ts
+                env:
+                  COPILOT_SDK_SOURCE_REF: ${{ parameters.COPILOT_SDK_SOURCE_REF }}
+                  COPILOT_SOURCE_VERSION: $(COPILOT_SOURCE_VERSION)
+                  COPILOT_RUNTIME_SOURCE_VERSION: $(COPILOT_SOURCE_VERSION)
+                  COPILOT_SOURCE_REGISTRY: $(NPM_REGISTRY)
+                  NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/copilot-source.npmrc
+                displayName: Build and publish Copilot SDK
+
+              - script: node build/azure-pipelines/common/queue-copilot-product-build.ts
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  VSCODE_PRODUCT_BUILD_DEFINITION_ID: ${{ parameters.VSCODE_PRODUCT_BUILD_DEFINITION_ID }}
+                  VSCODE_PRODUCT_SOURCE_BRANCH: ${{ parameters.VSCODE_PRODUCT_SOURCE_BRANCH }}
+                  VSCODE_QUALITY: ${{ parameters.VSCODE_QUALITY }}
+                  NPM_REGISTRY: $(NPM_REGISTRY)
+                  COPILOT_SDK_SOURCE_VERSION: $(COPILOT_SOURCE_VERSION)
+                  COPILOT_RUNTIME_SOURCE_VERSION: $(COPILOT_SOURCE_VERSION)
+                  VSCODE_PUBLISH: ${{ parameters.VSCODE_PUBLISH }}
+                  VSCODE_RELEASE: ${{ parameters.VSCODE_RELEASE }}
+                  VSCODE_WAIT_FOR_PRODUCT_BUILD: ${{ parameters.VSCODE_WAIT_FOR_PRODUCT_BUILD }}
+                displayName: Queue product build

--- a/build/azure-pipelines/copilot/source-publish-runtime-job.yml
+++ b/build/azure-pipelines/copilot/source-publish-runtime-job.yml
@@ -1,0 +1,62 @@
+parameters:
+  - name: target
+    type: string
+  - name: sourceRef
+    type: string
+
+jobs:
+  - job: Runtime_${{ replace(parameters.target, '-', '_') }}
+    displayName: ${{ parameters.target }}
+    timeoutInMinutes: 60
+    ${{ if startsWith(parameters.target, 'win32') }}:
+      pool:
+        name: 1es-windows-2022-x64
+        os: windows
+    ${{ elseif startsWith(parameters.target, 'darwin') }}:
+      pool:
+        name: AcesShared
+        os: macOS
+        demands:
+          - ImageOverride -equals ACES_VM_SharedPool_Sequoia
+    ${{ else }}:
+      pool:
+        name: 1es-ubuntu-22.04-x64
+        os: linux
+    variables:
+      VSCODE_COPILOT_TARGET: ${{ parameters.target }}
+      COPILOT_RUNTIME_STAGING: $(Build.ArtifactStagingDirectory)/copilot-runtime
+    templateContext:
+      outputs:
+        - output: pipelineArtifact
+          targetPath: $(COPILOT_RUNTIME_STAGING)
+          artifactName: copilot_runtime_${{ replace(parameters.target, '-', '_') }}
+          displayName: Publish ${{ parameters.target }} runtime artifact
+          sbomPackageName: "@github/copilot ${{ parameters.target }} (source build)"
+          sbomPackageVersion: $(COPILOT_SOURCE_VERSION)
+    steps:
+      - template: ../common/checkout.yml@self
+
+      - task: NodeTool@0
+        inputs:
+          versionSource: fromFile
+          versionFilePath: .nvmrc
+
+      - task: AzureKeyVault@2
+        displayName: Get Copilot runtime GitHub App key
+        inputs:
+          azureSubscription: vscode
+          KeyVaultName: vscode-build-secrets
+          SecretsFilter: copilot-agent-runtime-gh-app
+
+      - script: node build/azure-pipelines/common/prepare-copilot-runtime-source.ts
+        env:
+          COPILOT_RUNTIME_SOURCE_REF: ${{ parameters.sourceRef }}
+          GITHUB_APP_ID: "4297675"
+          GITHUB_APP_PRIVATE_KEY: $(copilot-agent-runtime-gh-app)
+        displayName: Prepare Copilot runtime source
+
+      - script: node build/azure-pipelines/common/install-runtime-build-toolchain.ts
+        displayName: Install runtime build toolchain
+
+      - script: node build/azure-pipelines/common/build-copilot-runtime-target.ts --target=$(VSCODE_COPILOT_TARGET) --out=$(COPILOT_RUNTIME_STAGING)
+        displayName: Build ${{ parameters.target }} from source

--- a/build/lib/copilotPlatforms.ts
+++ b/build/lib/copilotPlatforms.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The platforms that @github/copilot ships platform-specific packages for.
+ * These are the `@github/copilot-{platform}` optional dependency packages.
+ *
+ * Deliberately alone in a module with no imports: the runtime source build runs
+ * on agents that never install VS Code's dependencies, so anything it needs must
+ * be reachable without `npm ci`. Re-exported by copilot.ts for everything else.
+ */
+export const copilotPlatforms = [
+	'darwin-arm64', 'darwin-x64',
+	'linux-arm64', 'linux-x64',
+	'linuxmusl-arm64', 'linuxmusl-x64',
+	'win32-arm64', 'win32-x64',
+];

--- a/build/lib/copilotRuntimeSource.ts
+++ b/build/lib/copilotRuntimeSource.ts
@@ -1,0 +1,516 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { sourceBuildVersion } from '../azure-pipelines/common/copilotSource.ts';
+
+/**
+ * Full native source build of `@github/copilot` for the standalone source-build
+ * pipeline. Each target is built on its matching host OS and published as a
+ * pipeline artifact before the packages are assembled for the internal feed.
+ */
+
+const IS_WINDOWS = process.platform === 'win32';
+const PNPM = IS_WINDOWS ? 'pnpm.cmd' : 'pnpm';
+const COREPACK = IS_WINDOWS ? 'corepack.cmd' : 'corepack';
+
+/** Scratch dir (git-ignored under `.build`), relative to the repository root. */
+const OVERRIDES_DIR = path.join('.build', 'copilot-overrides');
+const RUNTIME_MARKER = path.join(OVERRIDES_DIR, 'runtime.json');
+const RUNTIME_SRC_DIR = path.join(OVERRIDES_DIR, 'runtime-src');
+/** Stamp recording which ref the checkout currently holds, for idempotency. */
+const CHECKOUT_STAMP = path.join(RUNTIME_SRC_DIR, '.copilot-source-ref');
+/** Finished per-target packages, keyed by ref + target so a repeat build is a copy. */
+const RUNTIME_PKGS_DIR = path.join(OVERRIDES_DIR, 'runtime-pkgs');
+/**
+ * Written last in a finished package dir, so a partial copy is never reused.
+ * Holds the commit it was built from, which is also what lets a packaging job
+ * prove a downloaded artifact belongs to the build it is packaging.
+ */
+const PACKAGE_STAMP = '.copilot-source-complete';
+/**
+ * Cargo output, deliberately outside the checkout: `ensureCheckout` wipes the
+ * checkout whenever the ref changes, which would otherwise discard every
+ * compiled dependency crate between hotfix iterations. Cargo namespaces builds
+ * by target triple, so all targets can share one directory.
+ */
+const CARGO_TARGET_DIR = path.join(OVERRIDES_DIR, 'cargo-target');
+/**
+ * Secret bridge file: the preparation step mints an installation token and
+ * writes it here for the source checkout step.
+ */
+const RUNTIME_TOKEN_FILE = path.join(OVERRIDES_DIR, 'runtime-token');
+
+interface RuntimeMarker {
+	readonly repo: string;
+	readonly ref: string;
+}
+
+/** The commit the runtime is being built from. */
+export function runtimeSourceRef(): string | undefined {
+	return isRuntimeSourceActive() ? readMarker().ref : undefined;
+}
+
+function run(command: string, args: string[], cwd: string, env: NodeJS.ProcessEnv = process.env): void {
+	console.log(`[copilot-runtime-source] $ ${command} ${redactSecrets(args.join(' '))}  (cwd: ${cwd})`);
+	// Only `.cmd`/`.bat` shims need a shell; git/node must not use one, or spaced
+	// args (e.g. the http.extraheader auth header) get split on Windows.
+	const shell = IS_WINDOWS && /\.(cmd|bat)$/i.test(command);
+	try {
+		execFileSync(command, args, { cwd, stdio: 'inherit', shell, env });
+	} catch (err) {
+		throw redactedError(err);
+	}
+}
+
+/**
+ * Re-wraps a `execFileSync` failure with credentials masked. Its message embeds
+ * the whole argument list, so an authenticated git call that fails would
+ * otherwise print a live token into the build log.
+ */
+export function redactedError(err: unknown): Error {
+	const message = err instanceof Error ? err.message : String(err);
+	return new Error(redactSecrets(message));
+}
+
+/** Masks credentials (tokens in URLs / auth headers) in a command or message. */
+export function redactSecrets(text: string): string {
+	return text
+		.replace(/(extraheader=AUTHORIZATION: [^\s]+ )\S+/gi, '$1***')
+		.replace(/\/\/[^@\s/]+@/g, '//***@');
+}
+
+/**
+ * Builds `git -c ...` args for a token, keeping it out of the clone URL (so it
+ * never lands in `.git/config`) and out of logs (redacted by
+ * {@link redactSecrets}). Always disables git's interactive credential
+ * fallback: in CI a bad or missing token must fail fast rather than block the
+ * job on a prompt that nobody can answer.
+ */
+export function gitAuthArgs(token: string | undefined): string[] {
+	const nonInteractive = ['-c', 'credential.helper=', '-c', 'core.askPass='];
+	if (!token) {
+		return nonInteractive;
+	}
+	const basic = Buffer.from(`x-access-token:${token}`).toString('base64');
+	return [...nonInteractive, '-c', `http.extraheader=AUTHORIZATION: basic ${basic}`];
+}
+
+/** Environment for git calls, with terminal credential prompting disabled. */
+export function gitEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	return { ...env, GIT_TERMINAL_PROMPT: '0' };
+}
+
+/**
+ * Environment for the runtime's own toolchain. Corepack asks for confirmation
+ * before downloading the pnpm version pinned by `packageManager`, which blocks
+ * on stdin that no CI job can answer.
+ */
+export function toolEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	return { ...env, COREPACK_ENABLE_DOWNLOAD_PROMPT: '0' };
+}
+
+/** Records the runtime source repository and commit for the build job. */
+export function writeRuntimeSourceMarker(repo: string, ref: string): void {
+	fs.mkdirSync(OVERRIDES_DIR, { recursive: true });
+	fs.writeFileSync(RUNTIME_MARKER, JSON.stringify({ repo, ref } satisfies RuntimeMarker, null, 2) + '\n');
+}
+
+/** Persists a clone token for the source checkout step (0600). */
+export function writeRuntimeToken(token: string): void {
+	fs.mkdirSync(OVERRIDES_DIR, { recursive: true });
+	fs.writeFileSync(RUNTIME_TOKEN_FILE, token, { mode: 0o600 });
+}
+
+/** Reads the token: explicit env wins, else the bridge file, else undefined. */
+function resolveCloneToken(): string | undefined {
+	const env = (process.env['COPILOT_OVERRIDE_TOKEN'] ?? '').trim();
+	if (env) {
+		return env;
+	}
+	if (fs.existsSync(RUNTIME_TOKEN_FILE)) {
+		const token = fs.readFileSync(RUNTIME_TOKEN_FILE, 'utf8').trim();
+		return token || undefined;
+	}
+	return undefined;
+}
+
+/** Whether a runtime source override is in effect for this build. */
+export function isRuntimeSourceActive(): boolean {
+	return fs.existsSync(RUNTIME_MARKER);
+}
+
+/**
+ * Retries an authenticated read from GitHub.
+ *
+ * A freshly minted GitHub App installation token is not always usable
+ * immediately — GitHub answers with `Repository not found` rather than a 401,
+ * so it is indistinguishable from a permissions problem and cannot be detected
+ * any more precisely than "it failed". Every target mints its own token and
+ * clones independently, so a blip that would once have hit one job now gets
+ * eight chances to fail the stage.
+ */
+export function withGitHubRetries<T>(what: string, attempt: () => T, delaysMs: readonly number[] = [2_000, 8_000, 20_000]): T {
+	for (let i = 0; ; i++) {
+		try {
+			return attempt();
+		} catch (err) {
+			if (i >= delaysMs.length) {
+				throw err;
+			}
+			console.log(`[copilot-runtime-source] ${what} failed (${redactSecrets(err instanceof Error ? err.message : String(err)).split('\n')[0]}); retrying in ${delaysMs[i] / 1000}s.`);
+			// Synchronous: the callers are sync and run inside a gulp packaging step.
+			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delaysMs[i]);
+		}
+	}
+}
+
+function readMarker(): RuntimeMarker {
+	return JSON.parse(fs.readFileSync(RUNTIME_MARKER, 'utf8'));
+}
+
+/**
+ * Clones the runtime at the marked ref and installs its dependencies, once.
+ * Idempotent across the many per-target calls in a single gulp run via a ref
+ * stamp. Returns the absolute checkout dir.
+ */
+function ensureCheckout(marker: RuntimeMarker): string {
+	const srcDir = path.resolve(RUNTIME_SRC_DIR);
+	if (fs.existsSync(CHECKOUT_STAMP) && fs.readFileSync(CHECKOUT_STAMP, 'utf8').trim() === marker.ref) {
+		return srcDir;
+	}
+
+	fs.rmSync(srcDir, { recursive: true, force: true });
+	fs.mkdirSync(srcDir, { recursive: true });
+
+	const token = resolveCloneToken();
+	const authArgs = gitAuthArgs(token);
+	const url = `https://github.com/${marker.repo}.git`;
+	// Fetch just the pinned commit (GitHub allows fetching a reachable SHA), then
+	// check it out. Falls back to a full fetch if the shallow SHA fetch is refused.
+	try {
+		run('git', ['init', '-q'], srcDir);
+		run('git', ['remote', 'add', 'origin', url], srcDir);
+		withGitHubRetries(`fetch ${marker.repo}@${marker.ref}`, () => {
+			try {
+				run('git', [...authArgs, 'fetch', '--depth', '1', 'origin', marker.ref], srcDir, gitEnv());
+			} catch {
+				console.log(`[copilot-runtime-source] Shallow fetch of ${marker.repo}@${marker.ref} failed; retrying with a full fetch.`);
+				run('git', [...authArgs, 'fetch', 'origin'], srcDir, gitEnv());
+			}
+		});
+		run('git', ['checkout', '-q', marker.ref], srcDir);
+	} finally {
+		// Nothing after the clone needs it, and the rest of the job has no business
+		// holding a live installation token inside the source tree.
+		fs.rmSync(RUNTIME_TOKEN_FILE, { force: true });
+	}
+
+	// corepack provisions the pnpm version pinned by the runtime's packageManager
+	// field; `--ignore-scripts` skips dependency lifecycle builds (the runtime's
+	// own native build is invoked explicitly per target below).
+	run(COREPACK, ['enable'], srcDir, toolEnv());
+	run(PNPM, ['install', '--frozen-lockfile', '--ignore-scripts'], srcDir, toolEnv());
+
+	fs.writeFileSync(CHECKOUT_STAMP, marker.ref);
+	console.log(`[copilot-runtime-source] Prepared runtime source ${marker.repo}@${marker.ref} at ${srcDir}`);
+	return srcDir;
+}
+
+interface BuildTarget {
+	/** `process.platform` value the Rust build targets: darwin | linux | win32. */
+	readonly nodePlatform: string;
+	/** `process.arch` value: x64 | arm64. */
+	readonly arch: string;
+	/** libc for Linux; ignored elsewhere. */
+	readonly libc: 'gnu' | 'musl';
+	/** Package platform id used by the runtime's packager: linux | linuxmusl | darwin | win32. */
+	readonly pkgPlatform: string;
+}
+
+/**
+ * Maps a copilot platform-package id (e.g. `linuxmusl-x64`, `darwin-arm64`) to
+ * the runtime's build arguments.
+ */
+function toBuildTarget(copilotPackagePlatformArch: string): BuildTarget {
+	const sep = copilotPackagePlatformArch.lastIndexOf('-');
+	const pkgPlatform = copilotPackagePlatformArch.slice(0, sep);
+	const arch = copilotPackagePlatformArch.slice(sep + 1);
+	const isMusl = pkgPlatform === 'linuxmusl';
+	return {
+		nodePlatform: isMusl ? 'linux' : pkgPlatform,
+		arch,
+		libc: isMusl ? 'musl' : 'gnu',
+		pkgPlatform,
+	};
+}
+
+/** Pipeline artifact name carrying the built package for one target. */
+export function runtimeArtifactName(copilotPackagePlatformArch: string): string {
+	return `copilot_runtime_${copilotPackagePlatformArch.replace(/-/g, '_')}`;
+}
+
+/**
+ * Builds one target from source and returns the directory holding the finished
+ * package, for a dedicated build job that publishes it as a pipeline artifact.
+ * Throws unless the preparation step wrote the runtime source marker.
+ */
+export function buildRuntimeTarget(copilotPackagePlatformArch: string): string {
+	if (!isRuntimeSourceActive()) {
+		throw new Error(`[copilot-runtime-source] No runtime source override is active, so ${copilotPackagePlatformArch} cannot be built from source.`);
+	}
+	return ensureTargetBuilt(readMarker(), copilotPackagePlatformArch);
+}
+
+/**
+ * The target this host can execute. Node reports `linux` for both libc flavors;
+ * the glibc package is the default and callers name `linuxmusl-*` explicitly.
+ */
+function hostTarget(): string {
+	return `${process.platform}-${process.arch}`;
+}
+
+/**
+ * Runs the built CLI, because a package can satisfy every structural assertion
+ * and still fail to load (a native addon built against the wrong Node ABI, a
+ * bundling regression). Skipped for cross-compiled targets, which cannot be
+ * executed on this host.
+ */
+export function smokeRunPackage(packageDir: string, copilotPackagePlatformArch: string): void {
+	if (copilotPackagePlatformArch !== hostTarget()) {
+		console.log(`[copilot-runtime-source] ${copilotPackagePlatformArch} is cross-compiled; skipping the smoke run.`);
+		return;
+	}
+	const entry = path.join(packageDir, 'index.js');
+	const version = execFileSync(process.execPath, [entry, '--version'], { encoding: 'utf8', timeout: 120_000 }).trim();
+	console.log(`[copilot-runtime-source] smoke run: ${entry} --version -> ${version}`);
+}
+
+/**
+ * Builds one target and returns the directory holding the finished package.
+ *
+ * Gulp asks for the same target once per packaging entry point (the desktop app
+ * and the server/REH both package `@github/copilot-<platform>-<arch>`), so
+ * without this reuse the expensive native build would run more than once per
+ * agent for identical output.
+ */
+function ensureTargetBuilt(marker: RuntimeMarker, copilotPackagePlatformArch: string): string {
+	const outDir = path.resolve(RUNTIME_PKGS_DIR, `${marker.ref}-${copilotPackagePlatformArch}`);
+	if (fs.existsSync(path.join(outDir, PACKAGE_STAMP))) {
+		console.log(`[copilot-runtime-source] Reusing built ${copilotPackagePlatformArch} at ${outDir}`);
+		return outDir;
+	}
+
+	const srcDir = ensureCheckout(marker);
+	assertBuildableSource(srcDir, `${marker.repo}@${marker.ref}`);
+	const target = toBuildTarget(copilotPackagePlatformArch);
+
+	// Rebuild dist-cli from scratch for this target so per-target trimming
+	// (prebuilds, platform native deps) from a previous target can't leak in.
+	const distCli = path.join(srcDir, 'dist-cli');
+	fs.rmSync(distCli, { recursive: true, force: true });
+
+	// 1. Compile the Rust napi addon for the target (cross-compiles as needed).
+	//    `--release` is explicit: the runtime infers release from `CI`/`GITHUB_ACTIONS`,
+	//    neither of which Azure Pipelines sets, so relying on inference would ship a
+	//    debug addon. An explicit `--release` wins over every other profile input.
+	const runtimeArgs = ['--release', `--platform=${target.nodePlatform}`, `--arch=${target.arch}`];
+	if (target.nodePlatform === 'linux') {
+		// Pass libc explicitly (gnu or musl) so the target never depends on the
+		// build host's detected libc.
+		runtimeArgs.push(`--libc=${target.libc}`);
+	}
+	run(PNPM, ['run', 'build:runtime', ...runtimeArgs], srcDir, toolEnv({
+		...process.env,
+		...installLinuxSysroot(srcDir, target),
+		CARGO_TARGET_DIR: path.resolve(CARGO_TARGET_DIR),
+	}));
+	// 2. Bundle the JS and copy native addons into dist-cli (CI=1 → minify).
+	run(PNPM, ['exec', 'tsx', 'esbuild.ts'], srcDir, toolEnv({ ...process.env, CI: '1' }));
+	// 3. Assemble the single-platform package (installs target native deps, trims).
+	run('node', ['script/cli-package-json.js', sourceBuildVersion(marker.ref), target.pkgPlatform, target.arch], srcDir);
+
+	assertPackageComplete(distCli, target, copilotPackagePlatformArch, srcDir);
+	stripSourceMaps(distCli);
+
+	fs.rmSync(outDir, { recursive: true, force: true });
+	fs.mkdirSync(outDir, { recursive: true });
+	fs.cpSync(distCli, outDir, { recursive: true });
+	fs.writeFileSync(path.join(outDir, PACKAGE_STAMP), `${marker.ref}\n`);
+	return outDir;
+}
+
+/**
+ * Removes source maps and their trailing `sourceMappingURL` comments, matching
+ * what the runtime's own publish workflow strips before shipping. Without this a
+ * source build ships ~47MB of maps for a private codebase that the published
+ * package does not contain.
+ */
+export function stripSourceMaps(distCli: string): number {
+	let removed = 0;
+	const walk = (dir: string): void => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(full);
+			} else if (entry.name.endsWith('.map')) {
+				fs.rmSync(full, { force: true });
+				removed++;
+			} else if (entry.name.endsWith('.js')) {
+				const source = fs.readFileSync(full, 'utf8');
+				const stripped = source.replace(/^\/\/# sourceMappingURL=.*$\n?/gm, '');
+				if (stripped !== source) {
+					fs.writeFileSync(full, stripped);
+				}
+			}
+		}
+	};
+	walk(distCli);
+	console.log(`[copilot-runtime-source] Stripped ${removed} source map(s) from ${distCli}`);
+	return removed;
+}
+
+/**
+ * Cargo/cc environment that links a Linux glibc target against `sysroot`.
+ *
+ * Mirrors the runtime's own release build. The sysroot's GCC must be the linker:
+ * the system GCC's CRT files reference newer glibc symbols that `--sysroot`
+ * alone cannot override.
+ */
+export function linuxSysrootEnv(arch: string, sysroot: string, binDir: string): NodeJS.ProcessEnv {
+	const triple = arch === 'arm64' ? 'aarch64-unknown-linux-gnu' : 'x86_64-unknown-linux-gnu';
+	const gccPrefix = arch === 'arm64' ? 'aarch64-linux-gnu' : 'x86_64-linux-gnu';
+	const upper = triple.replace(/-/g, '_').toUpperCase();
+	return {
+		[`CARGO_TARGET_${upper}_LINKER`]: path.join(binDir, `${gccPrefix}-gcc`),
+		[`CFLAGS_${triple.replace(/-/g, '_')}`]: `--sysroot=${sysroot}`,
+		[`CARGO_TARGET_${upper}_RUSTFLAGS`]: `-C link-arg=--sysroot=${sysroot}`,
+	};
+}
+
+/**
+ * Installs the glibc 2.28 sysroot the runtime's release build uses and returns
+ * the environment that targets it. Without this the addon links against the
+ * build agent's much newer glibc, raising the shipped package's `libc6` floor
+ * and dropping support for distros the published package still covers.
+ *
+ * Only glibc Linux targets need it; musl routes through cargo-zigbuild instead.
+ */
+function installLinuxSysroot(srcDir: string, target: BuildTarget): NodeJS.ProcessEnv {
+	if (target.nodePlatform !== 'linux' || target.libc !== 'gnu') {
+		return {};
+	}
+
+	const installer = path.join('script', 'linux', 'install-sysroot.cjs');
+	if (!fs.existsSync(path.join(srcDir, installer))) {
+		throw new Error(`[copilot-runtime-source] ${installer} is missing from the runtime checkout; a glibc Linux build would link against this agent's libc and raise the shipped libc6 floor.`);
+	}
+
+	console.log(`[copilot-runtime-source] $ node ${installer} ${target.arch}  (cwd: ${srcDir})`);
+	const output = execFileSync('node', [installer, target.arch], { cwd: srcDir, encoding: 'utf8', env: process.env });
+	const sysroot = /^SYSROOT_PATH=(.+)$/m.exec(output)?.[1]?.trim();
+	if (!sysroot) {
+		throw new Error(`[copilot-runtime-source] ${installer} printed no SYSROOT_PATH for ${target.arch}.`);
+	}
+
+	// Sysroot is <base>/<triple>/<triple>/sysroot, so ../../bin holds the toolchain.
+	const binDir = path.join(path.dirname(path.dirname(sysroot)), 'bin');
+	console.log(`[copilot-runtime-source] Linking ${target.arch} against sysroot ${sysroot}`);
+	return linuxSysrootEnv(target.arch, sysroot, binDir);
+}
+
+/**
+ * Fails early when a ref does not expose the build entry points driven below.
+ * This file reaches into the runtime's own build system, so a rename there would
+ * otherwise surface as an opaque pnpm/node error deep inside packaging — during
+ * a hotfix, which is the worst time to debug one.
+ */
+function assertBuildableSource(srcDir: string, source: string): void {
+	const manifest = JSON.parse(fs.readFileSync(path.join(srcDir, 'package.json'), 'utf8'));
+	const missing = [
+		...(manifest.scripts?.['build:runtime'] ? [] : ['package.json script "build:runtime"']),
+		...['esbuild.ts', path.join('script', 'cli-package-json.js')].filter(entry => !fs.existsSync(path.join(srcDir, entry))),
+	];
+	if (missing.length > 0) {
+		throw new Error(`[copilot-runtime-source] ${source} does not provide the runtime build entry points this integration drives (missing: ${missing.join(', ')}). Update the build recipe in build/lib/copilotRuntimeSource.ts to match.`);
+	}
+}
+
+/**
+ * Fails the build if the produced package is missing the pieces VS Code depends
+ * on. Without this a subtly wrong package (e.g. a native addon built for the
+ * host instead of the requested target) reaches the app and only surfaces as a
+ * runtime load failure on a user's machine.
+ */
+function assertPackageComplete(distCli: string, target: BuildTarget, copilotPackagePlatformArch: string, srcDir: string): void {
+	if (!fs.existsSync(distCli)) {
+		throw new Error(`[copilot-runtime-source] Runtime build produced no dist-cli/ for ${copilotPackagePlatformArch} in ${srcDir}.`);
+	}
+	// The SDK spawns `index.js`; the agent host loads `sdk/index.js` beside it.
+	for (const entry of ['index.js', path.join('sdk', 'index.js')]) {
+		if (!fs.existsSync(path.join(distCli, entry))) {
+			throw new Error(`[copilot-runtime-source] Runtime build for ${copilotPackagePlatformArch} is missing ${entry}.`);
+		}
+	}
+	// The runtime stages addons under the package platform name, so musl targets
+	// use `linuxmusl-<arch>`, and `cli-package-json.js` prunes every other
+	// target's directory. The Node platform name would miss musl entirely.
+	const prebuilds = path.join(distCli, 'prebuilds', copilotPackagePlatformArch);
+	const addons = fs.existsSync(prebuilds) ? fs.readdirSync(prebuilds).filter(name => name.endsWith('.node')) : [];
+	if (addons.length === 0) {
+		throw new Error(`[copilot-runtime-source] Runtime build for ${copilotPackagePlatformArch} produced no native addon in ${prebuilds}. Was the target cross-compiled?`);
+	}
+
+	// The directory name comes from the *requested* target, so a cross-compile
+	// that silently fell back to the host would still land here. Read the object
+	// header to confirm the binary really is for the requested architecture.
+	for (const addon of addons) {
+		const actual = readNativeArch(path.join(prebuilds, addon));
+		if (actual && actual !== target.arch) {
+			throw new Error(`[copilot-runtime-source] ${path.join(prebuilds, addon)} is a ${actual} binary but ${copilotPackagePlatformArch} was requested; the cross-compile fell back to the host.`);
+		}
+	}
+}
+
+/**
+ * The architecture a native addon was compiled for, read from its object header
+ * (Mach-O, ELF or PE). Returns undefined for a format or machine this does not
+ * recognise, so an unknown toolchain output is not treated as a mismatch.
+ */
+export function readNativeArch(file: string): 'x64' | 'arm64' | undefined {
+	const fd = fs.openSync(file, 'r');
+	try {
+		const head = Buffer.alloc(64);
+		if (fs.readSync(fd, head, 0, head.length, 0) < 64) {
+			return undefined;
+		}
+
+		// Mach-O 64-bit little-endian: magic 0xfeedfacf, then cputype.
+		if (head.readUInt32LE(0) === 0xfeedfacf) {
+			const cpuType = head.readUInt32LE(4);
+			return cpuType === 0x0100000c ? 'arm64' : cpuType === 0x01000007 ? 'x64' : undefined;
+		}
+		// ELF: magic \x7FELF, then e_machine at offset 18.
+		if (head.readUInt32BE(0) === 0x7f454c46) {
+			const machine = head.readUInt16LE(18);
+			return machine === 0xb7 ? 'arm64' : machine === 0x3e ? 'x64' : undefined;
+		}
+		// PE: 'MZ', PE header offset at 0x3c, machine at that offset + 4.
+		if (head.readUInt16BE(0) === 0x4d5a) {
+			const peOffset = head.readUInt32LE(0x3c);
+			const coff = Buffer.alloc(6);
+			if (fs.readSync(fd, coff, 0, coff.length, peOffset) < 6 || coff.readUInt32BE(0) !== 0x50450000) {
+				return undefined;
+			}
+			const machine = coff.readUInt16LE(4);
+			return machine === 0xaa64 ? 'arm64' : machine === 0x8664 ? 'x64' : undefined;
+		}
+		return undefined;
+	} finally {
+		fs.closeSync(fd);
+	}
+}

--- a/build/lib/test/copilotSourcePipeline.test.ts
+++ b/build/lib/test/copilotSourcePipeline.test.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, suite, test } from 'node:test';
+import { assembleRuntimePackages } from '../../azure-pipelines/common/copilotSourcePublish.ts';
+import { createProductBuildRequest } from '../../azure-pipelines/common/queue-copilot-product-build.ts';
+import { copilotPlatforms } from '../copilotPlatforms.ts';
+import { runtimeArtifactName } from '../copilotRuntimeSource.ts';
+
+let workspace: string;
+
+beforeEach(() => {
+	workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-source-pipeline-'));
+});
+
+afterEach(() => {
+	fs.rmSync(workspace, { recursive: true, force: true });
+});
+
+function writeRuntimeArtifact(target: string): void {
+	const dir = path.join(workspace, 'artifacts', runtimeArtifactName(target));
+	fs.mkdirSync(path.join(dir, 'sdk'), { recursive: true });
+	fs.writeFileSync(path.join(dir, 'index.js'), '// runtime\n');
+	fs.writeFileSync(path.join(dir, 'npm-loader.js'), '// loader\n');
+	fs.writeFileSync(path.join(dir, 'sdk', 'index.js'), '// sdk\n');
+	fs.writeFileSync(path.join(dir, 'sdk', 'index.d.ts'), 'export { };\n');
+	fs.writeFileSync(path.join(dir, '.copilot-source-complete'), 'a'.repeat(40));
+	fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
+		name: '@github/copilot',
+		version: '0.0.0-dev',
+		type: 'module',
+		dependencies: { 'detect-libc': '^2.1.2' },
+		files: ['index.js', 'npm-loader.js', 'sdk'],
+	}));
+}
+
+suite('Copilot source pipeline', () => {
+
+	test('assembles runtime packages for the internal feed', () => {
+		for (const target of copilotPlatforms) {
+			writeRuntimeArtifact(target);
+		}
+
+		const output = path.join(workspace, 'packages');
+		const packageDirs = assembleRuntimePackages(path.join(workspace, 'artifacts'), output, '0.0.0-vscode.123');
+		const mainManifest = JSON.parse(fs.readFileSync(path.join(output, 'copilot', 'package.json'), 'utf8'));
+		const muslManifest = JSON.parse(fs.readFileSync(path.join(output, 'linuxmusl-arm64', 'package.json'), 'utf8'));
+
+		assert.deepStrictEqual({
+			packageCount: packageDirs.length,
+			main: {
+				name: mainManifest.name,
+				version: mainManifest.version,
+				dependencies: mainManifest.dependencies,
+				optionalDependencies: mainManifest.optionalDependencies,
+			},
+			musl: {
+				name: muslManifest.name,
+				version: muslManifest.version,
+				os: muslManifest.os,
+				cpu: muslManifest.cpu,
+				libc: muslManifest.libc,
+				exports: muslManifest.exports,
+			},
+		}, {
+			packageCount: 9,
+			main: {
+				name: '@github/copilot',
+				version: '0.0.0-vscode.123',
+				dependencies: { 'detect-libc': '^2.1.2' },
+				optionalDependencies: Object.fromEntries(copilotPlatforms.map(target => [`@github/copilot-${target}`, '0.0.0-vscode.123'])),
+			},
+			musl: {
+				name: '@github/copilot-linuxmusl-arm64',
+				version: '0.0.0-vscode.123',
+				os: ['linux'],
+				cpu: ['arm64'],
+				libc: ['musl'],
+				exports: {
+					'.': './index.js',
+					'./sdk': {
+						types: './sdk/index.d.ts',
+						import: './sdk/index.js',
+					},
+				},
+			},
+		});
+	});
+
+	test('queues the product build with only supported override parameters', () => {
+		assert.deepStrictEqual(createProductBuildRequest({
+			definitionId: 111,
+			sourceBranch: 'feature/copilot-source',
+			quality: 'insider',
+			registry: 'https://example.test/npm/',
+			sdkVersion: '0.0.0-vscode.123',
+			runtimeVersion: '0.0.0-vscode.123',
+			publish: false,
+			release: false,
+		}), {
+			definition: { id: 111 },
+			sourceBranch: 'refs/heads/feature/copilot-source',
+			templateParameters: {
+				VSCODE_QUALITY: 'insider',
+				NPM_REGISTRY: 'https://example.test/npm/',
+				VSCODE_SDK_CANARY_VERSION: '0.0.0-vscode.123',
+				VSCODE_CLI_CANARY_VERSION: '0.0.0-vscode.123',
+				VSCODE_PUBLISH: false,
+				VSCODE_RELEASE: false,
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- add a standalone pipeline that builds the Copilot SDK and all runtime targets from source
- publish the source-built npm packages to the internal VS Code feed
- queue the existing product build with `VSCODE_SDK_CANARY_VERSION` and `VSCODE_CLI_CANARY_VERSION` overrides
- leave the existing product pipeline unchanged

## Validation

- `node --experimental-strip-types --test build/lib/test/copilotSourcePipeline.test.ts`
- pre-commit hygiene
- Azure Pipelines validation run: pending
- queued product build: pending