### PR TITLE
agentHost: use host session IDs for MCP channels

### DIFF
--- a/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
+++ b/src/vs/platform/agentHost/node/copilot/copilotAgentSession.ts
@@ -952,7 +952,7 @@ export class CopilotAgentSession extends Disposable {
 		}));
 		this._mcpCustomizations = this._register(this._instantiationService.createInstance(McpCustomizationController, {
 			providerId: this.resourceUri.scheme,
-			sessionId: this.sessionId,
+			sessionId: AgentSession.id(this.resourceUri),
 			sessionUri: this.resourceUri,
 			emit: action => this._emitAction(action),
 			pluginMcpServerSources: () => pluginMcpServerSources,

--- a/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
+++ b/src/vs/platform/agentHost/test/node/copilotAgentSession.test.ts
@@ -4806,6 +4806,7 @@ suite('CopilotAgentSession', () => {
 			// AHP `mcp://` channel is always available at `tool.execution_start`
 			// and is published as part of the initial `_meta.ui` payload.
 			const { mockSession, signals } = await createAgentSession(disposables, {
+				resource: AgentSession.uri('copilot', 'host-session'),
 				configureMockSession: m => {
 					m.mcpListResult = { servers: [{ name: 'docs', status: 'connected' }] };
 				},
@@ -4837,13 +4838,13 @@ suite('CopilotAgentSession', () => {
 				}, {
 					contributor: {
 						kind: ToolCallContributorKind.MCP,
-						customizationId: 'mcp-top-level:copilot:test-session-1:docs',
+						customizationId: 'mcp-top-level:copilot:host-session:docs',
 					},
 					meta: {
 						mcpServerName: 'docs',
 						ui: {
 							resourceUri: 'ui://docs',
-							channel: 'mcp://copilot/test-session-1/docs',
+							channel: 'mcp://copilot/host-session/docs',
 						},
 					},
 				});


### PR DESCRIPTION
## What changed

Agent Host debug logs showed MCP App `resources/read` requests failing with `Method not found: no active session` while a GitHub MCP tool was still running.

The emitted `mcp://` channel contained the Copilot SDK session ID. AHP interprets that segment as the host session ID, so routing failed whenever those IDs differed. This changes Copilot MCP customization identity and channels to use the canonical host session ID.

## Why this works

The host session resource is the identity used by `AgentService` to route MCP side-channel requests and by `CopilotAgent` to find the live session-backed chat. Using it keeps live customization IDs, replayed metadata, and AHP routing consistent.

The regression test uses distinct SDK and host session IDs. It passes with this fix and reproducibly fails without it.

Validation:
- `npm run transpile-client`
- Targeted `CopilotAgentSession` unit test
- Targeted ESLint
- Pre-commit hygiene

cc @connor4312 @sandy081 @roblourens

:warning: Generated by Copilot investigating Agent Host debug logs and auto-generating a PR to fix; this should not be merged unless a maintainer of the area approves.

Note I ran into the same error while my agent was fixing it!

<img width="977" height="598" alt="image" src="https://github.com/user-attachments/assets/2423a803-7c5d-440f-868c-8bc9cd3167a2" />
